### PR TITLE
Add offline Laravel-style archives application

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+APP_NAME="Arsip Surat"
+APP_ENV=local
+APP_DEBUG=true
+APP_URL=http://localhost
+
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=arsip_db
+DB_USERNAME=root
+DB_PASSWORD=
+
+SESSION_DRIVER=file

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/node_modules
+/public/assets
+/storage/backups/*.sql
+/storage/framework/*
+/storage/logs/*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# arsip
+# Arsip Surat Management
+
+Custom Laravel-style archive management system supporting authentication, dashboards, incoming/outgoing letter workflows, reporting, and system settings. Built without external dependencies to satisfy offline constraints.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Console;
+
+class Kernel
+{
+    // Placeholder console kernel.
+}

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Core;
+
+class Application
+{
+    protected Router $router;
+
+    public function __construct()
+    {
+        $this->router = new Router();
+    }
+
+    public function boot(): void
+    {
+        $this->registerRoutes();
+    }
+
+    protected function registerRoutes(): void
+    {
+        $router = $this->router;
+        require base_path('routes/web.php');
+        require base_path('routes/api.php');
+    }
+
+    public function router(): Router
+    {
+        return $this->router;
+    }
+
+    public function handle(Request $request): Response
+    {
+        return $this->router->dispatch($request);
+    }
+}

--- a/app/Core/Auth.php
+++ b/app/Core/Auth.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Core;
+
+use App\Models\User;
+
+class Auth
+{
+    public static function attempt(string $login, string $password): bool
+    {
+        $user = User::findByLogin($login);
+        if (!$user) {
+            return false;
+        }
+
+        if (!password_verify($password, $user['password'])) {
+            return false;
+        }
+
+        Session::put('user_id', $user['id']);
+        Session::put('user_role', $user['role']);
+        Session::put('user_name', $user['name']);
+        return true;
+    }
+
+    public static function user(): ?array
+    {
+        $id = Session::get('user_id');
+        if (!$id) {
+            return null;
+        }
+        return User::find($id);
+    }
+
+    public static function id(): ?int
+    {
+        return Session::get('user_id');
+    }
+
+    public static function check(): bool
+    {
+        return Session::get('user_id') !== null;
+    }
+
+    public static function logout(): void
+    {
+        Session::forget('user_id');
+        Session::forget('user_role');
+        Session::forget('user_name');
+    }
+
+    public static function isAdmin(): bool
+    {
+        return Session::get('user_role') === 'admin';
+    }
+}

--- a/app/Core/Database.php
+++ b/app/Core/Database.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Core;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class Database
+{
+    protected static ?PDO $connection = null;
+
+    public static function connection(): PDO
+    {
+        if (static::$connection === null) {
+            $config = config('database');
+            $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $config['host'], $config['port'], $config['database']);
+            try {
+                static::$connection = new PDO($dsn, $config['username'], $config['password'], [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                ]);
+            } catch (PDOException $e) {
+                throw new RuntimeException('Database connection failed: ' . $e->getMessage());
+            }
+        }
+
+        return static::$connection;
+    }
+}

--- a/app/Core/Request.php
+++ b/app/Core/Request.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Core;
+
+class Request
+{
+    protected array $query;
+    protected array $request;
+    protected array $files;
+    protected array $server;
+
+    public function __construct(array $query, array $request, array $files, array $server)
+    {
+        $this->query = $query;
+        $this->request = $request;
+        $this->files = $files;
+        $this->server = $server;
+    }
+
+    public static function capture(): self
+    {
+        return new self($_GET, $_POST, $_FILES, $_SERVER);
+    }
+
+    public function method(): string
+    {
+        return strtoupper($this->server['REQUEST_METHOD'] ?? 'GET');
+    }
+
+    public function path(): string
+    {
+        $uri = $this->server['REQUEST_URI'] ?? '/';
+        $parsed = parse_url($uri, PHP_URL_PATH);
+        return '/' . ltrim($parsed ?? '/', '/');
+    }
+
+    public function input(?string $key = null, $default = null)
+    {
+        if ($key === null) {
+            return array_merge($this->query, $this->request);
+        }
+        return $this->request[$key] ?? $this->query[$key] ?? $default;
+    }
+
+    public function file(string $key): ?array
+    {
+        return $this->files[$key] ?? null;
+    }
+
+    public function all(): array
+    {
+        return array_merge($this->query, $this->request);
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->query[$key]) || isset($this->request[$key]);
+    }
+}

--- a/app/Core/Response.php
+++ b/app/Core/Response.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Core;
+
+class Response
+{
+    protected string $content;
+    protected int $status;
+    protected array $headers;
+
+    public function __construct(string $content, int $status = 200, array $headers = [])
+    {
+        $this->content = $content;
+        $this->status = $status;
+        $this->headers = $headers;
+    }
+
+    public static function make(string $content = '', int $status = 200, array $headers = []): self
+    {
+        return new self($content, $status, $headers);
+    }
+
+    public static function json(array $data, int $status = 200, array $headers = []): self
+    {
+        $headers['Content-Type'] = 'application/json';
+        return new self(json_encode($data), $status, $headers);
+    }
+
+    public function send(): void
+    {
+        http_response_code($this->status);
+        foreach ($this->headers as $key => $value) {
+            header($key . ': ' . $value);
+        }
+        echo $this->content;
+    }
+}

--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Core;
+
+use App\Http\Middleware\MiddlewareInterface;
+use RuntimeException;
+
+class Router
+{
+    protected array $routes = [];
+
+    public function add(string $method, string $uri, callable|array $action, array $middleware = []): void
+    {
+        $method = strtoupper($method);
+        $this->routes[$method][] = [
+            'uri' => $uri,
+            'action' => $action,
+            'middleware' => $middleware,
+        ];
+    }
+
+    public function get(string $uri, callable|array $action, array $middleware = []): void
+    {
+        $this->add('GET', $uri, $action, $middleware);
+    }
+
+    public function post(string $uri, callable|array $action, array $middleware = []): void
+    {
+        $this->add('POST', $uri, $action, $middleware);
+    }
+
+    public function put(string $uri, callable|array $action, array $middleware = []): void
+    {
+        $this->add('PUT', $uri, $action, $middleware);
+    }
+
+    public function delete(string $uri, callable|array $action, array $middleware = []): void
+    {
+        $this->add('DELETE', $uri, $action, $middleware);
+    }
+
+    public function dispatch(Request $request): Response
+    {
+        $method = $request->method();
+        $path = $request->path();
+
+        foreach ($this->routes[$method] ?? [] as $route) {
+            $pattern = '#^' . preg_replace('#\{([^/]+)\}#', '(?P<$1>[^/]+)', $route['uri']) . '$#';
+            if (preg_match($pattern, $path, $matches)) {
+                $params = array_values(array_filter($matches, 'is_string', ARRAY_FILTER_USE_KEY));
+                return $this->runRoute($route, $request, $params);
+            }
+        }
+
+        return Response::make('Not Found', 404);
+    }
+
+    protected function runRoute(array $route, Request $request, array $params): Response
+    {
+        foreach ($route['middleware'] as $middlewareClass) {
+            /** @var MiddlewareInterface $middleware */
+            $middleware = new $middlewareClass();
+            $result = $middleware->handle($request);
+            if ($result instanceof Response) {
+                return $result;
+            }
+        }
+
+        $action = $route['action'];
+        if (is_callable($action)) {
+            $response = call_user_func_array($action, array_merge([$request], $params));
+        } elseif (is_array($action) && count($action) === 2) {
+            [$controllerClass, $method] = $action;
+            $controller = new $controllerClass();
+            $response = call_user_func_array([$controller, $method], array_merge([$request], $params));
+        } else {
+            throw new RuntimeException('Invalid route action.');
+        }
+
+        return $response instanceof Response ? $response : Response::make($response);
+    }
+}

--- a/app/Core/Session.php
+++ b/app/Core/Session.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Core;
+
+class Session
+{
+    public static function put(string $key, $value): void
+    {
+        $_SESSION[$key] = $value;
+    }
+
+    public static function get(string $key, $default = null)
+    {
+        return $_SESSION[$key] ?? $default;
+    }
+
+    public static function forget(string $key): void
+    {
+        unset($_SESSION[$key]);
+    }
+
+    public static function flush(): void
+    {
+        $_SESSION = [];
+    }
+
+    public static function flash(string $key, $value): void
+    {
+        session_flash($key, $value);
+    }
+}

--- a/app/Core/Validator.php
+++ b/app/Core/Validator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Core;
+
+class Validator
+{
+    protected array $data;
+    protected array $rules;
+    protected array $errors = [];
+
+    public function __construct(array $data, array $rules)
+    {
+        $this->data = $data;
+        $this->rules = $rules;
+        $this->validate();
+    }
+
+    public static function make(array $data, array $rules): self
+    {
+        return new self($data, $rules);
+    }
+
+    public function fails(): bool
+    {
+        return !empty($this->errors);
+    }
+
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    protected function validate(): void
+    {
+        foreach ($this->rules as $field => $rules) {
+            $value = $this->data[$field] ?? null;
+            foreach (explode('|', $rules) as $rule) {
+                if ($rule === 'required' && ($value === null || $value === '')) {
+                    $this->errors[$field][] = 'The ' . $field . ' field is required.';
+                }
+                if ($rule === 'email' && $value && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                    $this->errors[$field][] = 'The ' . $field . ' field must be a valid email address.';
+                }
+                if (str_starts_with($rule, 'max:') && $value !== null) {
+                    $max = (int) substr($rule, 4);
+                    if (is_string($value) && strlen($value) > $max) {
+                        $this->errors[$field][] = 'The ' . $field . ' may not be greater than ' . $max . ' characters.';
+                    }
+                }
+                if ($rule === 'date' && $value && !strtotime($value)) {
+                    $this->errors[$field][] = 'The ' . $field . ' must be a valid date.';
+                }
+            }
+        }
+    }
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Exceptions;
+
+use Throwable;
+
+class Handler
+{
+    public function report(Throwable $e): void
+    {
+        error_log($e->getMessage());
+    }
+
+    public function render(): void
+    {
+        http_response_code(500);
+        echo 'An unexpected error occurred.';
+    }
+}

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Auth;
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Session;
+use App\Core\Validator;
+
+class AuthController
+{
+    public function showLoginForm(Request $request): Response
+    {
+        if (Auth::check()) {
+            return Response::make('', 302, ['Location' => '/dashboard']);
+        }
+        $error = session_flash('auth_error');
+        $success = session_flash('status');
+        return Response::make(view('auth.login', compact('error', 'success')));
+    }
+
+    public function login(Request $request): Response
+    {
+        $data = $request->all();
+        $_SESSION['_old_input'] = $data;
+        $validator = Validator::make($data, [
+            'login' => 'required',
+            'password' => 'required',
+        ]);
+        if ($validator->fails()) {
+            Session::flash('auth_error', 'Please fill in your credentials.');
+            return Response::make('', 302, ['Location' => '/login']);
+        }
+
+        if (!verify_csrf($data['_token'] ?? '')) {
+            Session::flash('auth_error', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/login']);
+        }
+
+        if (!Auth::attempt($data['login'], $data['password'])) {
+            Session::flash('auth_error', 'Invalid credentials.');
+            return Response::make('', 302, ['Location' => '/login']);
+        }
+
+        unset($_SESSION['_old_input']);
+        return Response::make('', 302, ['Location' => '/dashboard']);
+    }
+
+    public function logout(): Response
+    {
+        Auth::logout();
+        Session::flash('status', 'You have been logged out.');
+        return Response::make('', 302, ['Location' => '/login']);
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Auth;
+use App\Core\Request;
+use App\Core\Response;
+use App\Models\IncomingLetter;
+use App\Models\OutgoingLetter;
+use App\Models\LetterCategory;
+
+class DashboardController
+{
+    public function index(): Response
+    {
+        $user = Auth::user();
+        if (!$user) {
+            return Response::make('', 302, ['Location' => '/login']);
+        }
+
+        if ($user['role'] === 'admin') {
+            $incomingCount = IncomingLetter::count();
+            $outgoingCount = OutgoingLetter::count();
+            $recentIncoming = IncomingLetter::latestWithRelations(5);
+            $recentOutgoing = OutgoingLetter::latestWithRelations(5);
+            $categories = LetterCategory::withCount();
+            return Response::make(view('dashboard.admin', compact(
+                'user',
+                'incomingCount',
+                'outgoingCount',
+                'recentIncoming',
+                'recentOutgoing',
+                'categories'
+            )));
+        }
+
+        $incomingCount = IncomingLetter::count(['created_by = ?' => [$user['id']]]);
+        $outgoingCount = OutgoingLetter::count(['created_by = ?' => [$user['id']]]);
+        $recentIncoming = IncomingLetter::latestWithRelations(5, $user['id']);
+        $recentOutgoing = OutgoingLetter::latestWithRelations(5, $user['id']);
+
+        return Response::make(view('dashboard.staff', compact(
+            'user',
+            'incomingCount',
+            'outgoingCount',
+            'recentIncoming',
+            'recentOutgoing'
+        )));
+    }
+
+    public function chartData(Request $request): Response
+    {
+        $user = Auth::user();
+        if (!$user) {
+            return Response::json(['message' => 'Unauthorized'], 401);
+        }
+
+        $year = $request->input('year', date('Y'));
+        $incomingData = $this->buildMonthlyData('surat_masuk', 'tanggal_masuk', $user);
+        $outgoingData = $this->buildMonthlyData('surat_keluar', 'tanggal_keluar', $user);
+
+        return Response::json([
+            'labels' => ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+            'incoming' => $incomingData,
+            'outgoing' => $outgoingData,
+        ]);
+    }
+
+    protected function buildMonthlyData(string $table, string $dateColumn, array $user): array
+    {
+        $pdo = \App\Core\Database::connection();
+        $sql = "SELECT MONTH($dateColumn) as month, COUNT(*) as total FROM {$table}";
+        $params = [];
+        $conditions = [];
+        if ($user['role'] === 'staff') {
+            $conditions[] = 'created_by = ?';
+            $params[] = $user['id'];
+        }
+        $conditions[] = "$dateColumn BETWEEN ? AND ?";
+        $params[] = date('Y-01-01');
+        $params[] = date('Y-12-31');
+        if ($conditions) {
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $sql .= ' GROUP BY MONTH($dateColumn)';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        $results = $stmt->fetchAll();
+        $data = array_fill(1, 12, 0);
+        foreach ($results as $row) {
+            $data[(int) $row['month']] = (int) $row['total'];
+        }
+        return array_values($data);
+    }
+}

--- a/app/Http/Controllers/IncomingLetterController.php
+++ b/app/Http/Controllers/IncomingLetterController.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Auth;
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Models\AuditTrail;
+use App\Models\IncomingLetter;
+use App\Models\LetterCategory;
+
+class IncomingLetterController
+{
+    public function index(Request $request): Response
+    {
+        $search = $request->input('search');
+        $user = Auth::user();
+        $letters = IncomingLetter::paginate($user['role'] === 'staff' ? $user['id'] : null, $search);
+        $categories = LetterCategory::all(order: 'nama_kategori ASC');
+        return Response::make(view('letters.incoming', compact('letters', 'categories', 'user')));
+    }
+
+    public function store(Request $request): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        $validator = Validator::make($data, [
+            'no_surat' => 'required',
+            'sender' => 'required',
+            'tanggal_masuk' => 'required|date',
+            'subject' => 'required',
+            'kategori_id' => 'required',
+        ]);
+        $file = $request->file('file');
+        if (!$file || $file['error'] !== UPLOAD_ERR_OK) {
+            session_flash('status', 'File upload is required.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        if (strtolower(pathinfo($file['name'], PATHINFO_EXTENSION)) !== 'pdf') {
+            session_flash('status', 'Only PDF files are allowed.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        if ($file['size'] > 10 * 1024 * 1024) {
+            session_flash('status', 'File size must not exceed 10 MB.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        if ($validator->fails()) {
+            session_flash('status', 'Please check the form fields.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+
+        $fileName = time() . '_' . preg_replace('/[^A-Za-z0-9_\-\.]/', '_', $file['name']);
+        $target = storage_path('uploads/incoming/' . $fileName);
+        if (!move_uploaded_file($file['tmp_name'], $target)) {
+            session_flash('status', 'Failed to store uploaded file.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+
+        $userId = Auth::id();
+        IncomingLetter::create([
+            'no_surat' => $data['no_surat'],
+            'sender' => $data['sender'],
+            'tanggal_masuk' => $data['tanggal_masuk'],
+            'subject' => $data['subject'],
+            'kategori_id' => $data['kategori_id'],
+            'file' => $fileName,
+            'created_by' => $userId,
+            'updated_by' => $userId,
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        AuditTrail::log($userId, 'create', 'Created incoming letter ' . $data['no_surat']);
+        session_flash('status', 'Incoming letter created successfully.');
+        return Response::make('', 302, ['Location' => '/incoming-letters']);
+    }
+
+    public function show(Request $request, int $id): Response
+    {
+        $letter = IncomingLetter::find($id);
+        if (!$letter) {
+            return Response::make('Letter not found', 404);
+        }
+        $category = LetterCategory::find($letter['kategori_id']);
+        return Response::make(view('letters.incoming_show', compact('letter', 'category')));
+    }
+
+    public function download(Request $request, int $id): Response
+    {
+        $letter = IncomingLetter::find($id);
+        if (!$letter) {
+            return Response::make('File not found', 404);
+        }
+        $filePath = storage_path('uploads/incoming/' . $letter['file']);
+        if (!file_exists($filePath)) {
+            return Response::make('File missing', 404);
+        }
+        $content = file_get_contents($filePath);
+        $disposition = $request->input('preview') ? 'inline' : 'attachment';
+        return new Response($content, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => $disposition . '; filename="' . basename($filePath) . '"',
+        ]);
+    }
+
+    public function destroy(int $id): Response
+    {
+        $letter = IncomingLetter::find($id);
+        if (!$letter) {
+            session_flash('status', 'Letter not found.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        $user = Auth::user();
+        if ($user['role'] !== 'admin' && $letter['created_by'] !== $user['id']) {
+            session_flash('status', 'You are not allowed to delete this record.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        IncomingLetter::delete($id);
+        $filePath = storage_path('uploads/incoming/' . $letter['file']);
+        if (file_exists($filePath)) {
+            unlink($filePath);
+        }
+        AuditTrail::log($user['id'], 'delete', 'Deleted incoming letter ' . $letter['no_surat']);
+        session_flash('status', 'Incoming letter deleted.');
+        return Response::make('', 302, ['Location' => '/incoming-letters']);
+    }
+
+    public function update(Request $request, int $id): Response
+    {
+        $letter = IncomingLetter::find($id);
+        if (!$letter) {
+            session_flash('status', 'Letter not found.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        $user = Auth::user();
+        if ($user['role'] !== 'admin' && $letter['created_by'] !== $user['id']) {
+            session_flash('status', 'You are not allowed to edit this record.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        $validator = Validator::make($data, [
+            'no_surat' => 'required',
+            'sender' => 'required',
+            'tanggal_masuk' => 'required|date',
+            'subject' => 'required',
+            'kategori_id' => 'required',
+        ]);
+        if ($validator->fails()) {
+            session_flash('status', 'Please check the form fields.');
+            return Response::make('', 302, ['Location' => '/incoming-letters']);
+        }
+        $file = $request->file('file');
+        $fileName = $letter['file'];
+        if ($file && $file['error'] === UPLOAD_ERR_OK) {
+            if (strtolower(pathinfo($file['name'], PATHINFO_EXTENSION)) !== 'pdf') {
+                session_flash('status', 'Only PDF files are allowed.');
+                return Response::make('', 302, ['Location' => '/incoming-letters']);
+            }
+            if ($file['size'] > 10 * 1024 * 1024) {
+                session_flash('status', 'File size must not exceed 10 MB.');
+                return Response::make('', 302, ['Location' => '/incoming-letters']);
+            }
+            $fileName = time() . '_' . preg_replace('/[^A-Za-z0-9_\-\.]/', '_', $file['name']);
+            $target = storage_path('uploads/incoming/' . $fileName);
+            move_uploaded_file($file['tmp_name'], $target);
+            $oldFile = storage_path('uploads/incoming/' . $letter['file']);
+            if (file_exists($oldFile)) {
+                unlink($oldFile);
+            }
+        }
+        IncomingLetter::update($id, [
+            'no_surat' => $data['no_surat'],
+            'sender' => $data['sender'],
+            'tanggal_masuk' => $data['tanggal_masuk'],
+            'subject' => $data['subject'],
+            'kategori_id' => $data['kategori_id'],
+            'file' => $fileName,
+            'updated_by' => $user['id'],
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        AuditTrail::log($user['id'], 'update', 'Updated incoming letter ' . $data['no_surat']);
+        session_flash('status', 'Incoming letter updated.');
+        return Response::make('', 302, ['Location' => '/incoming-letters']);
+    }
+}

--- a/app/Http/Controllers/LetterCategoryController.php
+++ b/app/Http/Controllers/LetterCategoryController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Auth;
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Models\LetterCategory;
+
+class LetterCategoryController
+{
+    public function index(): Response
+    {
+        $categories = LetterCategory::withCount();
+        return Response::make(view('categories.index', compact('categories')));
+    }
+
+    public function store(Request $request): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/letter-categories']);
+        }
+        $validator = Validator::make($data, [
+            'nama_kategori' => 'required',
+            'description' => 'required',
+        ]);
+        if ($validator->fails()) {
+            session_flash('status', 'Please fill all fields.');
+            return Response::make('', 302, ['Location' => '/letter-categories']);
+        }
+        if (isset($data['id']) && $data['id']) {
+            LetterCategory::update((int) $data['id'], [
+                'nama_kategori' => $data['nama_kategori'],
+                'description' => $data['description'],
+                'updated_at' => date('Y-m-d H:i:s'),
+            ]);
+            session_flash('status', 'Category updated successfully.');
+        } else {
+            LetterCategory::create([
+                'nama_kategori' => $data['nama_kategori'],
+                'description' => $data['description'],
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => date('Y-m-d H:i:s'),
+            ]);
+            session_flash('status', 'Category created successfully.');
+        }
+        return Response::make('', 302, ['Location' => '/letter-categories']);
+    }
+
+    public function destroy(int $id): Response
+    {
+        LetterCategory::delete($id);
+        session_flash('status', 'Category deleted.');
+        return Response::make('', 302, ['Location' => '/letter-categories']);
+    }
+}

--- a/app/Http/Controllers/OutgoingLetterController.php
+++ b/app/Http/Controllers/OutgoingLetterController.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Auth;
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Models\AuditTrail;
+use App\Models\OutgoingLetter;
+use App\Models\LetterCategory;
+
+class OutgoingLetterController
+{
+    public function index(Request $request): Response
+    {
+        $search = $request->input('search');
+        $user = Auth::user();
+        $letters = OutgoingLetter::paginate($user['role'] === 'staff' ? $user['id'] : null, $search);
+        $categories = LetterCategory::all(order: 'nama_kategori ASC');
+        return Response::make(view('letters.outgoing', compact('letters', 'categories', 'user')));
+    }
+
+    public function store(Request $request): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        $validator = Validator::make($data, [
+            'no_surat' => 'required',
+            'receiver' => 'required',
+            'tanggal_keluar' => 'required|date',
+            'subject' => 'required',
+            'kategori_id' => 'required',
+        ]);
+        $file = $request->file('file');
+        if (!$file || $file['error'] !== UPLOAD_ERR_OK) {
+            session_flash('status', 'File upload is required.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        if (strtolower(pathinfo($file['name'], PATHINFO_EXTENSION)) !== 'pdf') {
+            session_flash('status', 'Only PDF files are allowed.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        if ($file['size'] > 10 * 1024 * 1024) {
+            session_flash('status', 'File size must not exceed 10 MB.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        if ($validator->fails()) {
+            session_flash('status', 'Please check the form fields.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+
+        $fileName = time() . '_' . preg_replace('/[^A-Za-z0-9_\-\.]/', '_', $file['name']);
+        $target = storage_path('uploads/outgoing/' . $fileName);
+        if (!move_uploaded_file($file['tmp_name'], $target)) {
+            session_flash('status', 'Failed to store uploaded file.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        $userId = Auth::id();
+        OutgoingLetter::create([
+            'no_surat' => $data['no_surat'],
+            'receiver' => $data['receiver'],
+            'tanggal_keluar' => $data['tanggal_keluar'],
+            'subject' => $data['subject'],
+            'kategori_id' => $data['kategori_id'],
+            'file' => $fileName,
+            'created_by' => $userId,
+            'updated_by' => $userId,
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        AuditTrail::log($userId, 'create', 'Created outgoing letter ' . $data['no_surat']);
+        session_flash('status', 'Outgoing letter created successfully.');
+        return Response::make('', 302, ['Location' => '/outgoing-letters']);
+    }
+
+    public function show(int $id): Response
+    {
+        $letter = OutgoingLetter::find($id);
+        if (!$letter) {
+            return Response::make('Letter not found', 404);
+        }
+        $category = LetterCategory::find($letter['kategori_id']);
+        return Response::make(view('letters.outgoing_show', compact('letter', 'category')));
+    }
+
+    public function download(Request $request, int $id): Response
+    {
+        $letter = OutgoingLetter::find($id);
+        if (!$letter) {
+            return Response::make('File not found', 404);
+        }
+        $filePath = storage_path('uploads/outgoing/' . $letter['file']);
+        if (!file_exists($filePath)) {
+            return Response::make('File missing', 404);
+        }
+        $content = file_get_contents($filePath);
+        $disposition = $request->input('preview') ? 'inline' : 'attachment';
+        return new Response($content, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => $disposition . '; filename="' . basename($filePath) . '"',
+        ]);
+    }
+
+    public function destroy(int $id): Response
+    {
+        $letter = OutgoingLetter::find($id);
+        if (!$letter) {
+            session_flash('status', 'Letter not found.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        $user = Auth::user();
+        if ($user['role'] !== 'admin' && $letter['created_by'] !== $user['id']) {
+            session_flash('status', 'You are not allowed to delete this record.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        OutgoingLetter::delete($id);
+        $filePath = storage_path('uploads/outgoing/' . $letter['file']);
+        if (file_exists($filePath)) {
+            unlink($filePath);
+        }
+        AuditTrail::log($user['id'], 'delete', 'Deleted outgoing letter ' . $letter['no_surat']);
+        session_flash('status', 'Outgoing letter deleted.');
+        return Response::make('', 302, ['Location' => '/outgoing-letters']);
+    }
+
+    public function update(Request $request, int $id): Response
+    {
+        $letter = OutgoingLetter::find($id);
+        if (!$letter) {
+            session_flash('status', 'Letter not found.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        $user = Auth::user();
+        if ($user['role'] !== 'admin' && $letter['created_by'] !== $user['id']) {
+            session_flash('status', 'You are not allowed to edit this record.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        $validator = Validator::make($data, [
+            'no_surat' => 'required',
+            'receiver' => 'required',
+            'tanggal_keluar' => 'required|date',
+            'subject' => 'required',
+            'kategori_id' => 'required',
+        ]);
+        if ($validator->fails()) {
+            session_flash('status', 'Please check the form fields.');
+            return Response::make('', 302, ['Location' => '/outgoing-letters']);
+        }
+        $file = $request->file('file');
+        $fileName = $letter['file'];
+        if ($file && $file['error'] === UPLOAD_ERR_OK) {
+            if (strtolower(pathinfo($file['name'], PATHINFO_EXTENSION)) !== 'pdf') {
+                session_flash('status', 'Only PDF files are allowed.');
+                return Response::make('', 302, ['Location' => '/outgoing-letters']);
+            }
+            if ($file['size'] > 10 * 1024 * 1024) {
+                session_flash('status', 'File size must not exceed 10 MB.');
+                return Response::make('', 302, ['Location' => '/outgoing-letters']);
+            }
+            $fileName = time() . '_' . preg_replace('/[^A-Za-z0-9_\-\.]/', '_', $file['name']);
+            $target = storage_path('uploads/outgoing/' . $fileName);
+            move_uploaded_file($file['tmp_name'], $target);
+            $oldFile = storage_path('uploads/outgoing/' . $letter['file']);
+            if (file_exists($oldFile)) {
+                unlink($oldFile);
+            }
+        }
+        OutgoingLetter::update($id, [
+            'no_surat' => $data['no_surat'],
+            'receiver' => $data['receiver'],
+            'tanggal_keluar' => $data['tanggal_keluar'],
+            'subject' => $data['subject'],
+            'kategori_id' => $data['kategori_id'],
+            'file' => $fileName,
+            'updated_by' => $user['id'],
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        AuditTrail::log($user['id'], 'update', 'Updated outgoing letter ' . $data['no_surat']);
+        session_flash('status', 'Outgoing letter updated.');
+        return Response::make('', 302, ['Location' => '/outgoing-letters']);
+    }
+}

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Request;
+use App\Core\Response;
+use App\Services\ExcelExporter;
+use App\Services\PdfExporter;
+use App\Services\ReportService;
+
+class ReportController
+{
+    protected ReportService $reports;
+
+    public function __construct()
+    {
+        $this->reports = new ReportService();
+    }
+
+    public function index(Request $request): Response
+    {
+        $type = $request->input('type', 'incoming');
+        $period = $request->input('period', 'monthly');
+        $date = $request->input('date', date('Y-m-d'));
+        $rows = $this->reports->getData($type, $period, $date);
+        return Response::make(view('reports.index', compact('type', 'period', 'date', 'rows')));
+    }
+
+    public function exportPdf(Request $request): Response
+    {
+        $type = $request->input('type', 'incoming');
+        $period = $request->input('period', 'monthly');
+        $date = $request->input('date', date('Y-m-d'));
+        $rows = $this->reports->getData($type, $period, $date);
+        $columns = $this->columns($type);
+        $pdf = (new PdfExporter())->generate(strtoupper($type) . ' Letters Report', $columns, $rows);
+        return new Response($pdf, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'attachment; filename="report-' . $type . '.pdf"',
+        ]);
+    }
+
+    public function exportExcel(Request $request): Response
+    {
+        $type = $request->input('type', 'incoming');
+        $period = $request->input('period', 'monthly');
+        $date = $request->input('date', date('Y-m-d'));
+        $rows = $this->reports->getData($type, $period, $date);
+        $columns = $this->columns($type);
+        $csv = (new ExcelExporter())->generate(strtoupper($type) . ' Letters Report', $columns, $rows);
+        return new Response($csv, 200, [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="report-' . $type . '.csv"',
+        ]);
+    }
+
+    protected function columns(string $type): array
+    {
+        if ($type === 'outgoing') {
+            return [
+                ['label' => 'Letter Number', 'key' => 'no_surat'],
+                ['label' => 'Receiver', 'key' => 'receiver'],
+                ['label' => 'Date Sent', 'key' => 'tanggal_keluar'],
+                ['label' => 'Subject', 'key' => 'subject'],
+                ['label' => 'Category', 'key' => 'nama_kategori'],
+                ['label' => 'Created By', 'key' => 'creator'],
+            ];
+        }
+        return [
+            ['label' => 'Letter Number', 'key' => 'no_surat'],
+            ['label' => 'Sender', 'key' => 'sender'],
+            ['label' => 'Date Received', 'key' => 'tanggal_masuk'],
+            ['label' => 'Subject', 'key' => 'subject'],
+            ['label' => 'Category', 'key' => 'nama_kategori'],
+            ['label' => 'Created By', 'key' => 'creator'],
+        ];
+    }
+}

--- a/app/Http/Controllers/SystemSettingController.php
+++ b/app/Http/Controllers/SystemSettingController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Models\SystemSetting;
+use App\Services\BackupService;
+
+class SystemSettingController
+{
+    public function index(): Response
+    {
+        $settings = SystemSetting::current();
+        return Response::make(view('settings.index', compact('settings')));
+    }
+
+    public function save(Request $request): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/settings']);
+        }
+        $validator = Validator::make($data, [
+            'institution_name' => 'required',
+            'institution_address' => 'required',
+            'max_upload_size' => 'required',
+        ]);
+        if ($validator->fails()) {
+            session_flash('status', 'Please fill in all required fields.');
+            return Response::make('', 302, ['Location' => '/settings']);
+        }
+        $logo = $request->file('logo');
+        $logoPath = null;
+        if ($logo && $logo['error'] === UPLOAD_ERR_OK) {
+            $allowed = ['png', 'jpg', 'jpeg', 'svg'];
+            $ext = strtolower(pathinfo($logo['name'], PATHINFO_EXTENSION));
+            if (!in_array($ext, $allowed, true)) {
+                session_flash('status', 'Logo must be an image (PNG, JPG, SVG).');
+                return Response::make('', 302, ['Location' => '/settings']);
+            }
+            $logoPath = 'logos/' . time() . '_' . preg_replace('/[^A-Za-z0-9_\-\.]/', '_', $logo['name']);
+            $target = storage_path('app/' . $logoPath);
+            @mkdir(dirname($target), 0777, true);
+            move_uploaded_file($logo['tmp_name'], $target);
+        }
+        $attributes = [
+            'institution_name' => $data['institution_name'],
+            'institution_address' => $data['institution_address'],
+            'max_upload_size' => (int) $data['max_upload_size'],
+            'file_mime' => 'application/pdf',
+            'updated_at' => date('Y-m-d H:i:s'),
+        ];
+        if ($logoPath) {
+            $attributes['logo_path'] = $logoPath;
+        }
+        $settings = SystemSetting::current();
+        if ($settings) {
+            SystemSetting::update($settings['id'], $attributes);
+        } else {
+            $attributes['created_at'] = date('Y-m-d H:i:s');
+            SystemSetting::create($attributes);
+        }
+        session_flash('status', 'Settings saved successfully.');
+        return Response::make('', 302, ['Location' => '/settings']);
+    }
+
+    public function backup(): Response
+    {
+        $service = new BackupService();
+        $path = $service->createBackup();
+        $content = file_get_contents($path);
+        return new Response($content, 200, [
+            'Content-Type' => 'application/sql',
+            'Content-Disposition' => 'attachment; filename="' . basename($path) . '"',
+        ]);
+    }
+
+    public function restore(Request $request): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/settings']);
+        }
+        $file = $request->file('backup');
+        if (!$file || $file['error'] !== UPLOAD_ERR_OK) {
+            session_flash('status', 'Backup file is required.');
+            return Response::make('', 302, ['Location' => '/settings']);
+        }
+        $sql = file_get_contents($file['tmp_name']);
+        $service = new BackupService();
+        try {
+            $service->restore($sql);
+            session_flash('status', 'Database restored successfully.');
+        } catch (\Throwable $e) {
+            session_flash('status', 'Restore failed: ' . $e->getMessage());
+        }
+        return Response::make('', 302, ['Location' => '/settings']);
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\Validator;
+use App\Models\AuditTrail;
+use App\Models\User;
+
+class UserController
+{
+    public function index(): Response
+    {
+        $users = User::all(order: 'created_at DESC');
+        return Response::make(view('users.index', compact('users')));
+    }
+
+    public function store(Request $request): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/users']);
+        }
+        $validator = Validator::make($data, [
+            'name' => 'required',
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+        if ($validator->fails()) {
+            session_flash('status', 'Please check the form fields.');
+            return Response::make('', 302, ['Location' => '/users']);
+        }
+        User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => password_hash($data['password'], PASSWORD_BCRYPT),
+            'role' => $data['role'] ?? 'staff',
+            'status' => 'active',
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        AuditTrail::log($_SESSION['user_id'], 'create', 'Created staff ' . $data['name']);
+        session_flash('status', 'User created successfully.');
+        return Response::make('', 302, ['Location' => '/users']);
+    }
+
+    public function update(Request $request, int $id): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/users']);
+        }
+        $validator = Validator::make($data, [
+            'name' => 'required',
+            'email' => 'required|email',
+            'role' => 'required',
+            'status' => 'required',
+        ]);
+        if ($validator->fails()) {
+            session_flash('status', 'Please check the form fields.');
+            return Response::make('', 302, ['Location' => '/users']);
+        }
+        User::update($id, [
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'role' => $data['role'],
+            'status' => $data['status'],
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        AuditTrail::log($_SESSION['user_id'], 'update', 'Updated user ' . $data['name']);
+        session_flash('status', 'User updated successfully.');
+        return Response::make('', 302, ['Location' => '/users']);
+    }
+
+    public function resetPassword(Request $request, int $id): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/users']);
+        }
+        $password = $data['password'] ?? 'password123';
+        User::update($id, [
+            'password' => password_hash($password, PASSWORD_BCRYPT),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+        AuditTrail::log($_SESSION['user_id'], 'update', 'Reset password for user ID ' . $id);
+        session_flash('status', 'Password reset successfully.');
+        return Response::make('', 302, ['Location' => '/users']);
+    }
+
+    public function destroy(Request $request, int $id): Response
+    {
+        $data = $request->all();
+        if (!verify_csrf($data['_token'] ?? '')) {
+            session_flash('status', 'Invalid session token.');
+            return Response::make('', 302, ['Location' => '/users']);
+        }
+        User::delete($id);
+        AuditTrail::log($_SESSION['user_id'], 'delete', 'Deleted user ID ' . $id);
+        session_flash('status', 'User removed successfully.');
+        return Response::make('', 302, ['Location' => '/users']);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http;
+
+class Kernel
+{
+    // Placeholder kernel for structure compliance.
+}

--- a/app/Http/Middleware/AdminOnly.php
+++ b/app/Http/Middleware/AdminOnly.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Core\Auth;
+use App\Core\Request;
+use App\Core\Response;
+
+class AdminOnly implements MiddlewareInterface
+{
+    public function handle(Request $request): ?Response
+    {
+        if (!Auth::isAdmin()) {
+            return Response::make(view('errors.403'), 403);
+        }
+        return null;
+    }
+}

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Core\Auth;
+use App\Core\Request;
+use App\Core\Response;
+
+class Authenticate implements MiddlewareInterface
+{
+    public function handle(Request $request): ?Response
+    {
+        if (!Auth::check() && $request->path() !== '/login') {
+            return Response::make('', 302, ['Location' => '/login']);
+        }
+        return null;
+    }
+}

--- a/app/Http/Middleware/MiddlewareInterface.php
+++ b/app/Http/Middleware/MiddlewareInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Core\Request;
+use App\Core\Response;
+
+interface MiddlewareInterface
+{
+    public function handle(Request $request): ?Response;
+}

--- a/app/Models/AuditTrail.php
+++ b/app/Models/AuditTrail.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+class AuditTrail extends Model
+{
+    protected static string $table = 'audit_trails';
+    protected static array $fillable = [
+        'user_id',
+        'action',
+        'description',
+        'created_at',
+    ];
+
+    public static function log(int $userId, string $action, string $description): void
+    {
+        static::create([
+            'user_id' => $userId,
+            'action' => $action,
+            'description' => $description,
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/app/Models/IncomingLetter.php
+++ b/app/Models/IncomingLetter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+class IncomingLetter extends Model
+{
+    protected static string $table = 'surat_masuk';
+    protected static array $fillable = [
+        'no_surat',
+        'sender',
+        'tanggal_masuk',
+        'subject',
+        'kategori_id',
+        'file',
+        'created_by',
+        'updated_by',
+        'created_at',
+        'updated_at',
+    ];
+
+    public static function latestWithRelations(int $limit = 5, ?int $userId = null): array
+    {
+        $sql = 'SELECT sm.*, k.nama_kategori, u.name as creator FROM surat_masuk sm
+                JOIN kategori_surat k ON k.id = sm.kategori_id
+                JOIN users u ON u.id = sm.created_by';
+        $params = [];
+        if ($userId) {
+            $sql .= ' WHERE sm.created_by = ?';
+            $params[] = $userId;
+        }
+        $sql .= ' ORDER BY sm.tanggal_masuk DESC, sm.created_at DESC LIMIT ' . (int) $limit;
+        return static::query($sql, $params);
+    }
+
+    public static function paginate(?int $userId = null, ?string $search = null): array
+    {
+        $sql = 'SELECT sm.*, k.nama_kategori, u.name as creator FROM surat_masuk sm
+                JOIN kategori_surat k ON k.id = sm.kategori_id
+                JOIN users u ON u.id = sm.created_by';
+        $params = [];
+        $conditions = [];
+        if ($userId) {
+            $conditions[] = 'sm.created_by = ?';
+            $params[] = $userId;
+        }
+        if ($search) {
+            $conditions[] = '(sm.no_surat LIKE ? OR sm.subject LIKE ? OR sm.sender LIKE ?)';
+            $params[] = "%$search%";
+            $params[] = "%$search%";
+            $params[] = "%$search%";
+        }
+        if ($conditions) {
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $sql .= ' ORDER BY sm.tanggal_masuk DESC';
+        return static::query($sql, $params);
+    }
+}

--- a/app/Models/LetterCategory.php
+++ b/app/Models/LetterCategory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+class LetterCategory extends Model
+{
+    protected static string $table = 'kategori_surat';
+    protected static array $fillable = [
+        'nama_kategori',
+        'description',
+        'created_at',
+        'updated_at',
+    ];
+
+    public static function withCount(): array
+    {
+        $sql = 'SELECT k.*, (
+                    SELECT COUNT(*) FROM surat_masuk WHERE kategori_id = k.id
+                ) as incoming_count,
+                (
+                    SELECT COUNT(*) FROM surat_keluar WHERE kategori_id = k.id
+                ) as outgoing_count
+                FROM kategori_surat k ORDER BY k.nama_kategori ASC';
+        return static::query($sql);
+    }
+}

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Models;
+
+use App\Core\Database;
+
+abstract class Model
+{
+    protected static string $table;
+    protected static array $fillable = [];
+
+    public static function all(array $conditions = [], ?string $order = null, ?int $limit = null): array
+    {
+        $pdo = Database::connection();
+        $sql = 'SELECT * FROM ' . static::$table;
+        $params = [];
+        if ($conditions) {
+            $clauses = [];
+            foreach ($conditions as $field => $value) {
+                if (is_array($value)) {
+                    $clauses[] = $field;
+                    $params = array_merge($params, $value);
+                } else {
+                    $clauses[] = "$field = ?";
+                    $params[] = $value;
+                }
+            }
+            $sql .= ' WHERE ' . implode(' AND ', $clauses);
+        }
+        if ($order) {
+            $sql .= ' ORDER BY ' . $order;
+        }
+        if ($limit) {
+            $sql .= ' LIMIT ' . (int) $limit;
+        }
+
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll();
+    }
+
+    public static function find(int $id): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT * FROM ' . static::$table . ' WHERE id = ?');
+        $stmt->execute([$id]);
+        $result = $stmt->fetch();
+        return $result ?: null;
+    }
+
+    public static function create(array $attributes): int
+    {
+        $pdo = Database::connection();
+        $fields = array_intersect_key($attributes, array_flip(static::$fillable));
+        $columns = array_keys($fields);
+        $placeholders = array_fill(0, count($columns), '?');
+        $sql = 'INSERT INTO ' . static::$table . ' (' . implode(',', $columns) . ') VALUES (' . implode(',', $placeholders) . ')';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($fields));
+        return (int) $pdo->lastInsertId();
+    }
+
+    public static function update(int $id, array $attributes): void
+    {
+        $pdo = Database::connection();
+        $fields = array_intersect_key($attributes, array_flip(static::$fillable));
+        $columns = array_keys($fields);
+        if (!$columns) {
+            return;
+        }
+        $assignments = implode(',', array_map(fn($column) => "$column = ?", $columns));
+        $sql = 'UPDATE ' . static::$table . ' SET ' . $assignments . ' WHERE id = ?';
+        $stmt = $pdo->prepare($sql);
+        $params = array_values($fields);
+        $params[] = $id;
+        $stmt->execute($params);
+    }
+
+    public static function delete(int $id): void
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('DELETE FROM ' . static::$table . ' WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+
+    public static function count(array $conditions = []): int
+    {
+        $pdo = Database::connection();
+        $sql = 'SELECT COUNT(*) FROM ' . static::$table;
+        $params = [];
+        if ($conditions) {
+            $clauses = [];
+            foreach ($conditions as $field => $value) {
+                if (is_array($value)) {
+                    $clauses[] = $field;
+                    $params = array_merge($params, $value);
+                } else {
+                    $clauses[] = "$field = ?";
+                    $params[] = $value;
+                }
+            }
+            $sql .= ' WHERE ' . implode(' AND ', $clauses);
+        }
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        return (int) $stmt->fetchColumn();
+    }
+
+    public static function query(string $sql, array $params = []): array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll();
+    }
+
+    public static function raw(string $sql, array $params = []): void
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+    }
+}

--- a/app/Models/OutgoingLetter.php
+++ b/app/Models/OutgoingLetter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+class OutgoingLetter extends Model
+{
+    protected static string $table = 'surat_keluar';
+    protected static array $fillable = [
+        'no_surat',
+        'receiver',
+        'tanggal_keluar',
+        'subject',
+        'kategori_id',
+        'file',
+        'created_by',
+        'updated_by',
+        'created_at',
+        'updated_at',
+    ];
+
+    public static function latestWithRelations(int $limit = 5, ?int $userId = null): array
+    {
+        $sql = 'SELECT sk.*, k.nama_kategori, u.name as creator FROM surat_keluar sk
+                JOIN kategori_surat k ON k.id = sk.kategori_id
+                JOIN users u ON u.id = sk.created_by';
+        $params = [];
+        if ($userId) {
+            $sql .= ' WHERE sk.created_by = ?';
+            $params[] = $userId;
+        }
+        $sql .= ' ORDER BY sk.tanggal_keluar DESC, sk.created_at DESC LIMIT ' . (int) $limit;
+        return static::query($sql, $params);
+    }
+
+    public static function paginate(?int $userId = null, ?string $search = null): array
+    {
+        $sql = 'SELECT sk.*, k.nama_kategori, u.name as creator FROM surat_keluar sk
+                JOIN kategori_surat k ON k.id = sk.kategori_id
+                JOIN users u ON u.id = sk.created_by';
+        $params = [];
+        $conditions = [];
+        if ($userId) {
+            $conditions[] = 'sk.created_by = ?';
+            $params[] = $userId;
+        }
+        if ($search) {
+            $conditions[] = '(sk.no_surat LIKE ? OR sk.subject LIKE ? OR sk.receiver LIKE ?)';
+            $params[] = "%$search%";
+            $params[] = "%$search%";
+            $params[] = "%$search%";
+        }
+        if ($conditions) {
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $sql .= ' ORDER BY sk.tanggal_keluar DESC';
+        return static::query($sql, $params);
+    }
+}

--- a/app/Models/SystemSetting.php
+++ b/app/Models/SystemSetting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+class SystemSetting extends Model
+{
+    protected static string $table = 'system_settings';
+    protected static array $fillable = [
+        'institution_name',
+        'institution_address',
+        'logo_path',
+        'max_upload_size',
+        'file_mime',
+        'created_at',
+        'updated_at',
+    ];
+
+    public static function current(): ?array
+    {
+        $settings = static::all(order: 'id DESC', limit: 1);
+        return $settings[0] ?? null;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+class User extends Model
+{
+    protected static string $table = 'users';
+    protected static array $fillable = [
+        'name',
+        'email',
+        'password',
+        'role',
+        'status',
+        'created_at',
+        'updated_at',
+    ];
+
+    public static function findByLogin(string $login): ?array
+    {
+        $pdo = \App\Core\Database::connection();
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE email = ? OR name = ? LIMIT 1');
+        $stmt->execute([$login, $login]);
+        $user = $stmt->fetch();
+        return $user ?: null;
+    }
+
+    public static function staff(): array
+    {
+        return static::all(['role = ?' => ['staff']], 'name ASC');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Providers;
+
+class AppServiceProvider
+{
+    public function register(): void
+    {
+        // Placeholder for service bindings.
+    }
+
+    public function boot(): void
+    {
+        // Placeholder for boot logic.
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Providers;
+
+class AuthServiceProvider
+{
+    public function boot(): void
+    {
+        // Placeholder for auth services.
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Providers;
+
+class RouteServiceProvider
+{
+    public function boot(): void
+    {
+        // Placeholder for route configuration.
+    }
+}

--- a/app/Services/BackupService.php
+++ b/app/Services/BackupService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+use App\Core\Database;
+use RuntimeException;
+
+class BackupService
+{
+    protected array $tables = [
+        'users',
+        'kategori_surat',
+        'surat_masuk',
+        'surat_keluar',
+        'system_settings',
+        'audit_trails',
+    ];
+
+    public function createBackup(): string
+    {
+        $pdo = Database::connection();
+        $lines = [];
+        $lines[] = '-- Backup generated at ' . date('Y-m-d H:i:s');
+        foreach ($this->tables as $table) {
+            $lines[] = "-- Table {$table}";
+            $lines[] = "DELETE FROM `{$table}`;";
+            $stmt = $pdo->query('SELECT * FROM ' . $table);
+            while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+                $columns = array_map(fn($col) => "`{$col}`", array_keys($row));
+                $values = array_map(fn($value) => $value === null ? 'NULL' : $pdo->quote($value), array_values($row));
+                $lines[] = 'INSERT INTO `' . $table . '` (' . implode(',', $columns) . ') VALUES (' . implode(',', $values) . ');';
+            }
+        }
+        $content = implode("\n", $lines);
+        $fileName = 'backup_' . date('Ymd_His') . '.sql';
+        $path = storage_path('backups/' . $fileName);
+        file_put_contents($path, $content);
+        return $path;
+    }
+
+    public function restore(string $sql): void
+    {
+        $pdo = Database::connection();
+        $pdo->beginTransaction();
+        try {
+            foreach (array_filter(array_map('trim', explode(';', $sql))) as $statement) {
+                if ($statement === '' || str_starts_with($statement, '--')) {
+                    continue;
+                }
+                $pdo->exec($statement);
+            }
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            $pdo->rollBack();
+            throw new RuntimeException('Restore failed: ' . $e->getMessage());
+        }
+    }
+}

--- a/app/Services/ExcelExporter.php
+++ b/app/Services/ExcelExporter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services;
+
+class ExcelExporter
+{
+    public function generate(string $title, array $columns, array $rows): string
+    {
+        $lines = [];
+        $lines[] = $title;
+        $lines[] = implode(',', array_map([$this, 'escape'], array_column($columns, 'label')));
+        foreach ($rows as $row) {
+            $line = [];
+            foreach ($columns as $column) {
+                $value = $row[$column['key']] ?? '';
+                $line[] = $this->escape(is_scalar($value) ? (string) $value : json_encode($value));
+            }
+            $lines[] = implode(',', $line);
+        }
+        return implode("\r\n", $lines);
+    }
+
+    protected function escape(string $value): string
+    {
+        $needsQuotes = str_contains($value, ',') || str_contains($value, '"') || str_contains($value, "\n");
+        $value = str_replace('"', '""', $value);
+        return $needsQuotes ? '"' . $value . '"' : $value;
+    }
+}

--- a/app/Services/PdfExporter.php
+++ b/app/Services/PdfExporter.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services;
+
+class PdfExporter
+{
+    public function generate(string $title, array $columns, array $rows): string
+    {
+        $streamLines = [];
+        $streamLines[] = 'BT';
+        $streamLines[] = '/F1 18 Tf';
+        $streamLines[] = '72 820 Td';
+        $streamLines[] = '(' . $this->escape($title) . ') Tj';
+        $streamLines[] = '/F1 12 Tf';
+        $streamLines[] = 'T*';
+        $streamLines[] = '(' . $this->escape(implode(' | ', array_column($columns, 'label'))) . ') Tj';
+        foreach ($rows as $row) {
+            $line = [];
+            foreach ($columns as $column) {
+                $value = $row[$column['key']] ?? '';
+                $line[] = is_scalar($value) ? (string) $value : json_encode($value);
+            }
+            $streamLines[] = 'T*';
+            $streamLines[] = '(' . $this->escape(implode(' | ', $line)) . ') Tj';
+        }
+        $streamLines[] = 'ET';
+        $streamContent = implode("\n", $streamLines);
+
+        $objects = [];
+        $objects[] = '1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj';
+        $objects[] = '2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj';
+        $objects[] = '3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj';
+        $objects[] = '4 0 obj << /Length ' . strlen($streamContent) . ' >> stream\n' . $streamContent . '\nendstream\nendobj';
+        $objects[] = '5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj';
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [0];
+        foreach ($objects as $object) {
+            $offsets[] = strlen($pdf);
+            $pdf .= $object . "\n";
+        }
+        $xrefOffset = strlen($pdf);
+        $count = count($objects) + 1;
+        $pdf .= 'xref\n';
+        $pdf .= '0 ' . $count . "\n";
+        $pdf .= "0000000000 65535 f \n";
+        for ($i = 1; $i < $count; $i++) {
+            $pdf .= sprintf('%010d 00000 n \n', $offsets[$i]);
+        }
+        $pdf .= 'trailer << /Size ' . $count . ' /Root 1 0 R >>\n';
+        $pdf .= 'startxref\n' . $xrefOffset . "\n%%EOF";
+
+        return $pdf;
+    }
+
+    protected function escape(string $value): string
+    {
+        return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $value);
+    }
+}

--- a/app/Services/ReportService.php
+++ b/app/Services/ReportService.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services;
+
+use App\Core\Auth;
+use App\Models\IncomingLetter;
+use App\Models\OutgoingLetter;
+
+class ReportService
+{
+    public function getData(string $type, string $period, ?string $date = null): array
+    {
+        $user = Auth::user();
+        $conditions = [];
+        $params = [];
+        $date = $date ?? date('Y-m-d');
+
+        if ($type === 'outgoing') {
+            $table = 'surat_keluar sk';
+            $dateColumn = 'sk.tanggal_keluar';
+            $baseSql = 'SELECT sk.*, k.nama_kategori, u.name as creator FROM surat_keluar sk
+                        JOIN kategori_surat k ON k.id = sk.kategori_id
+                        JOIN users u ON u.id = sk.created_by';
+        } else {
+            $table = 'surat_masuk sm';
+            $dateColumn = 'sm.tanggal_masuk';
+            $baseSql = 'SELECT sm.*, k.nama_kategori, u.name as creator FROM surat_masuk sm
+                        JOIN kategori_surat k ON k.id = sm.kategori_id
+                        JOIN users u ON u.id = sm.created_by';
+        }
+
+        if ($user && $user['role'] === 'staff') {
+            $conditions[] = 'u.id = ?';
+            $params[] = $user['id'];
+        }
+
+        if ($period === 'daily') {
+            $conditions[] = "$dateColumn = ?";
+            $params[] = $date;
+        } elseif ($period === 'monthly') {
+            $conditions[] = "MONTH($dateColumn) = ? AND YEAR($dateColumn) = ?";
+            $params[] = date('m', strtotime($date));
+            $params[] = date('Y', strtotime($date));
+        } elseif ($period === 'yearly') {
+            $conditions[] = "YEAR($dateColumn) = ?";
+            $params[] = date('Y', strtotime($date));
+        }
+
+        $sql = $baseSql;
+        if ($conditions) {
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $sql .= ' ORDER BY ' . $dateColumn . ' DESC';
+
+        return $type === 'outgoing'
+            ? OutgoingLetter::query($sql, $params)
+            : IncomingLetter::query($sql, $params);
+    }
+}

--- a/app/Support/Env.php
+++ b/app/Support/Env.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Support;
+
+class Env
+{
+    public static function load(string $basePath): void
+    {
+        $envFile = rtrim($basePath, '/') . '/.env';
+        if (!is_readable($envFile)) {
+            return;
+        }
+
+        $lines = file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        foreach ($lines as $line) {
+            $trimmed = trim($line);
+            if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+                continue;
+            }
+
+            [$name, $value] = array_map('trim', explode('=', $line, 2));
+            $value = self::sanitizeValue($value);
+            $_ENV[$name] = $value;
+            $_SERVER[$name] = $value;
+        }
+    }
+
+    protected static function sanitizeValue(string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return $value;
+        }
+
+        $first = $value[0];
+        $last = $value[strlen($value) - 1];
+        if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+            return substr($value, 1, -1);
+        }
+        return $value;
+    }
+}

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -1,0 +1,161 @@
+<?php
+
+if (!function_exists('base_path')) {
+    function base_path(string $path = ''): string
+    {
+        return rtrim(__DIR__ . '/../..', '/') . ($path ? '/' . ltrim($path, '/') : '');
+    }
+}
+
+if (!function_exists('config_path')) {
+    function config_path(string $path = ''): string
+    {
+        return base_path('config' . ($path ? '/' . ltrim($path, '/') : ''));
+    }
+}
+
+if (!function_exists('storage_path')) {
+    function storage_path(string $path = ''): string
+    {
+        return base_path('storage' . ($path ? '/' . ltrim($path, '/') : ''));
+    }
+}
+
+if (!function_exists('public_path')) {
+    function public_path(string $path = ''): string
+    {
+        return base_path('public' . ($path ? '/' . ltrim($path, '/') : ''));
+    }
+}
+
+if (!function_exists('resource_path')) {
+    function resource_path(string $path = ''): string
+    {
+        return base_path('resources' . ($path ? '/' . ltrim($path, '/') : ''));
+    }
+}
+
+if (!function_exists('env')) {
+    function env(string $key, $default = null)
+    {
+        $value = $_ENV[$key] ?? $_SERVER[$key] ?? $default;
+        if ($value === null) {
+            return $default;
+        }
+
+        switch (strtolower($value)) {
+            case 'true':
+            case '(true)':
+                return true;
+            case 'false':
+            case '(false)':
+                return false;
+            case 'null':
+            case '(null)':
+                return null;
+            default:
+                return $value;
+        }
+    }
+}
+
+if (!function_exists('config')) {
+    function config(string $key, $default = null)
+    {
+        static $configs = [];
+
+        if (!$configs) {
+            foreach (glob(config_path('*.php')) as $file) {
+                $name = basename($file, '.php');
+                $configs[$name] = require $file;
+            }
+        }
+
+        [$file, $item] = array_pad(explode('.', $key, 2), 2, null);
+        if ($item === null) {
+            return $configs[$file] ?? $default;
+        }
+
+        return $configs[$file][$item] ?? $default;
+    }
+}
+
+if (!function_exists('view')) {
+    function view(string $template, array $data = []): string
+    {
+        $path = resource_path('views/' . str_replace('.', '/', $template) . '.blade.php');
+        if (!file_exists($path)) {
+            throw new RuntimeException("View {$template} not found.");
+        }
+
+        extract($data, EXTR_SKIP);
+        ob_start();
+        include $path;
+        return ob_get_clean();
+    }
+}
+
+if (!function_exists('redirect')) {
+    function redirect(string $url): void
+    {
+        header('Location: ' . $url);
+        exit;
+    }
+}
+
+if (!function_exists('url')) {
+    function url(string $path = ''): string
+    {
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        return rtrim($scheme . '://' . $host, '/') . '/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('asset')) {
+    function asset(string $path): string
+    {
+        return url($path);
+    }
+}
+
+if (!function_exists('old')) {
+    function old(string $key, $default = '')
+    {
+        if (!isset($_SESSION['_old_input'][$key])) {
+            return $default;
+        }
+        $value = $_SESSION['_old_input'][$key];
+        unset($_SESSION['_old_input'][$key]);
+        return $value;
+    }
+}
+
+if (!function_exists('session_flash')) {
+    function session_flash(string $key, $value = null)
+    {
+        if ($value === null) {
+            $data = $_SESSION['_flash'][$key] ?? null;
+            unset($_SESSION['_flash'][$key]);
+            return $data;
+        }
+        $_SESSION['_flash'][$key] = $value;
+    }
+}
+
+if (!function_exists('csrf_token')) {
+    function csrf_token(): string
+    {
+        if (!isset($_SESSION['_token'])) {
+            $_SESSION['_token'] = bin2hex(random_bytes(16));
+        }
+        return $_SESSION['_token'];
+    }
+}
+
+if (!function_exists('verify_csrf')) {
+    function verify_csrf(string $token): bool
+    {
+        return isset($_SESSION['_token']) && hash_equals($_SESSION['_token'], $token);
+    }
+}

--- a/artisan
+++ b/artisan
@@ -1,0 +1,45 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+use App\Support\Env;
+use Database\Migrations\CreateTables;
+use Database\Seeders\DatabaseSeeder;
+use App\Services\BackupService;
+
+Env::load(__DIR__);
+
+$command = $argv[1] ?? null;
+
+switch ($command) {
+    case 'migrate':
+        (new CreateTables())->up();
+        echo "Migrations completed.\n";
+        break;
+    case 'db:seed':
+        (new DatabaseSeeder())->run();
+        echo "Database seeding completed.\n";
+        break;
+    case 'backup:run':
+        $path = (new BackupService())->createBackup();
+        echo "Backup created at {$path}\n";
+        break;
+    case 'backup:restore':
+        $file = $argv[2] ?? null;
+        if (!$file || !file_exists($file)) {
+            echo "Please provide a valid SQL file path.\n";
+            exit(1);
+        }
+        $sql = file_get_contents($file);
+        (new BackupService())->restore($sql);
+        echo "Backup restored successfully.\n";
+        break;
+    default:
+        echo "Available commands:\n";
+        echo "  migrate\n";
+        echo "  db:seed\n";
+        echo "  backup:run\n";
+        echo "  backup:restore <file>\n";
+        exit($command ? 1 : 0);
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Core\Application;
+use App\Support\Env;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+Env::load(__DIR__ . '/..');
+
+$app = new Application();
+$app->boot();
+
+return $app;

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "arsip/custom-laravel",
+    "type": "project",
+    "require": {},
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/",
+            "Database\\Seeders\\": "database/seeders/",
+            "Database\\Migrations\\": "database/migrations/"
+        }
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'name' => env('APP_NAME', 'Arsip Surat'),
+    'env' => env('APP_ENV', 'local'),
+    'debug' => env('APP_DEBUG', true),
+    'url' => env('APP_URL', 'http://localhost'),
+];

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'driver' => 'mysql',
+    'host' => env('DB_HOST', '127.0.0.1'),
+    'port' => env('DB_PORT', 3306),
+    'database' => env('DB_DATABASE', 'arsip'),
+    'username' => env('DB_USERNAME', 'root'),
+    'password' => env('DB_PASSWORD', ''),
+];

--- a/database/migrations/2025_01_01_000000_create_tables.php
+++ b/database/migrations/2025_01_01_000000_create_tables.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Database\Migrations;
+
+use App\Core\Database;
+
+class CreateTables
+{
+    public function up(): void
+    {
+        $pdo = Database::connection();
+        $queries = [
+            'CREATE TABLE IF NOT EXISTS users (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(150) NOT NULL,
+                email VARCHAR(150) NOT NULL UNIQUE,
+                password VARCHAR(255) NOT NULL,
+                role ENUM("admin","staff") NOT NULL DEFAULT "staff",
+                status VARCHAR(20) DEFAULT "active",
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            'CREATE TABLE IF NOT EXISTS kategori_surat (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                nama_kategori VARCHAR(150) NOT NULL,
+                description TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            'CREATE TABLE IF NOT EXISTS surat_masuk (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                no_surat VARCHAR(150) NOT NULL,
+                sender VARCHAR(150) NOT NULL,
+                tanggal_masuk DATE NOT NULL,
+                subject VARCHAR(255) NOT NULL,
+                kategori_id INT NOT NULL,
+                file VARCHAR(255) NOT NULL,
+                created_by INT NOT NULL,
+                updated_by INT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                FOREIGN KEY (kategori_id) REFERENCES kategori_surat(id) ON DELETE CASCADE,
+                FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE,
+                FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            'CREATE TABLE IF NOT EXISTS surat_keluar (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                no_surat VARCHAR(150) NOT NULL,
+                receiver VARCHAR(150) NOT NULL,
+                tanggal_keluar DATE NOT NULL,
+                subject VARCHAR(255) NOT NULL,
+                kategori_id INT NOT NULL,
+                file VARCHAR(255) NOT NULL,
+                created_by INT NOT NULL,
+                updated_by INT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                FOREIGN KEY (kategori_id) REFERENCES kategori_surat(id) ON DELETE CASCADE,
+                FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE,
+                FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            'CREATE TABLE IF NOT EXISTS system_settings (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                institution_name VARCHAR(255) NOT NULL,
+                institution_address TEXT NOT NULL,
+                logo_path VARCHAR(255) NULL,
+                max_upload_size INT DEFAULT 10240,
+                file_mime VARCHAR(50) DEFAULT "application/pdf",
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            'CREATE TABLE IF NOT EXISTS audit_trails (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                user_id INT NOT NULL,
+                action VARCHAR(50) NOT NULL,
+                description TEXT NOT NULL,
+                created_at TIMESTAMP NULL,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+        ];
+
+        foreach ($queries as $sql) {
+            $pdo->exec($sql);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Core\Database;
+
+class DatabaseSeeder
+{
+    public function run(): void
+    {
+        $pdo = Database::connection();
+        $existing = $pdo->query("SELECT COUNT(*) FROM users WHERE role = 'admin'")->fetchColumn();
+        if ($existing == 0) {
+            $stmt = $pdo->prepare('INSERT INTO users (name, email, password, role, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, NOW(), NOW())');
+            $stmt->execute([
+                'Administrator',
+                'admin@example.com',
+                password_hash('password123', PASSWORD_BCRYPT),
+                'admin',
+                'active',
+            ]);
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "arsip-app",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Core\Request;
+
+$app = require __DIR__ . '/../bootstrap/app.php';
+
+$request = Request::capture();
+$response = $app->handle($request);
+$response->send();

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,0 +1,75 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+    font-family: 'Inter', sans-serif;
+    background-color: #f5f6fa;
+}
+
+.sidebar {
+    min-width: 250px;
+    background: linear-gradient(180deg, #1f2937 0%, #111827 100%);
+    color: #f9fafb;
+}
+
+.sidebar a {
+    display: block;
+    padding: 0.75rem 1.25rem;
+    border-radius: 0.75rem;
+    color: inherit;
+    text-decoration: none;
+    margin-bottom: 0.5rem;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.sidebar a.active,
+.sidebar a:hover {
+    background-color: rgba(59, 130, 246, 0.2);
+    transform: translateX(4px);
+}
+
+.card {
+    background: #ffffff;
+    border-radius: 1rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    padding: 1.5rem;
+}
+
+.table-wrapper {
+    background: #ffffff;
+    border-radius: 1rem;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.05);
+}
+
+.table-wrapper table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table-wrapper th,
+.table-wrapper td {
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid #eef2f7;
+}
+
+.badge {
+    border-radius: 9999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.badge-success {
+    background-color: rgba(16, 185, 129, 0.15);
+    color: #047857;
+}
+
+.badge-warning {
+    background-color: rgba(251, 191, 36, 0.15);
+    color: #92400e;
+}
+
+.modal {
+    background-color: rgba(15, 23, 42, 0.45);
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toggles = document.querySelectorAll('[data-toggle]');
+    toggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const target = document.querySelector(toggle.dataset.toggle);
+            if (target) {
+                target.classList.toggle('hidden');
+            }
+        });
+    });
+
+    const closeButtons = document.querySelectorAll('[data-close]');
+    closeButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const target = document.querySelector(button.dataset.close);
+            if (target) {
+                target.classList.add('hidden');
+            }
+        });
+    });
+
+    const toast = document.querySelector('[data-toast]');
+    if (toast) {
+        setTimeout(() => {
+            toast.classList.add('opacity-0');
+        }, 4000);
+    }
+});

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - <?= htmlspecialchars(config('app.name')) ?></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-slate-900 flex items-center justify-center">
+    <div class="bg-white rounded-2xl shadow-2xl p-10 max-w-md w-full space-y-6">
+        <h1 class="text-3xl font-semibold text-slate-800 text-center">Welcome Back</h1>
+        <?php if (!empty($success)): ?>
+            <div class="bg-emerald-100 text-emerald-700 px-3 py-2 rounded-lg text-sm"><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
+        <?php if (!empty($error)): ?>
+            <div class="bg-rose-100 text-rose-600 px-3 py-2 rounded-lg text-sm"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+        <form method="POST" action="/login" class="space-y-4">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <div>
+                <label class="text-sm text-slate-600">Email or Username</label>
+                <input type="text" name="login" value="<?= htmlspecialchars(old('login')) ?>" class="mt-1 w-full px-4 py-3 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-600">Password</label>
+                <input type="password" name="password" class="mt-1 w-full px-4 py-3 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+            </div>
+            <button class="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 rounded-lg">Sign In</button>
+        </form>
+        <p class="text-xs text-center text-slate-400">Default admin: admin@example.com / password123</p>
+    </div>
+</body>
+</html>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -1,0 +1,80 @@
+<?php ob_start(); ?>
+<div class="flex items-center justify-between">
+    <h1 class="text-2xl font-semibold text-slate-700">Letter Categories</h1>
+    <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg" data-toggle="#categoryModal">Add Category</button>
+</div>
+<div class="table-wrapper mt-6">
+    <table>
+        <thead>
+            <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                <th>Name</th>
+                <th>Description</th>
+                <th>Total Letters</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($categories as $category): ?>
+                <tr class="text-sm text-slate-600">
+                    <td><?= htmlspecialchars($category['nama_kategori']) ?></td>
+                    <td><?= htmlspecialchars($category['description'] ?? '-') ?></td>
+                    <td><?= (int) $category['incoming_count'] + (int) $category['outgoing_count'] ?></td>
+                    <td class="space-x-2">
+                        <button type="button" class="text-amber-600" data-toggle="#categoryModal" data-category='<?= json_encode($category) ?>'>Edit</button>
+                        <form action="/letter-categories/<?= $category['id'] ?>/delete" method="POST" class="inline">
+                            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+                            <button class="text-rose-600" onclick="return confirm('Delete this category?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+
+<div id="categoryModal" class="modal fixed inset-0 hidden items-center justify-center">
+    <div class="bg-white rounded-2xl shadow-2xl max-w-xl w-full p-6 space-y-4">
+        <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-slate-700">Manage Category</h2>
+            <button data-close="#categoryModal">&times;</button>
+        </div>
+        <form id="categoryForm" method="POST" class="space-y-4">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <input type="hidden" name="id">
+            <div>
+                <label class="text-sm text-slate-500">Category Name</label>
+                <input type="text" name="nama_kategori" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Description</label>
+                <textarea name="description" class="w-full px-3 py-2 border rounded-lg" rows="3" required></textarea>
+            </div>
+            <div class="flex justify-end gap-3">
+                <button type="button" class="px-4 py-2 border rounded-lg" data-close="#categoryModal">Cancel</button>
+                <button class="px-4 py-2 bg-blue-600 text-white rounded-lg">Save</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('[data-category]').forEach(button => {
+            button.addEventListener('click', () => {
+                const data = JSON.parse(button.dataset.category);
+                const form = document.getElementById('categoryForm');
+                form.action = '/letter-categories';
+                form.querySelector('[name=id]').value = data.id;
+                form.querySelector('[name=nama_kategori]').value = data.nama_kategori;
+                form.querySelector('[name=description]').value = data.description || '';
+            });
+        });
+        document.querySelector('[data-toggle="#categoryModal"]').addEventListener('click', () => {
+            const form = document.getElementById('categoryForm');
+            form.querySelector('[name=id]').value = '';
+            form.querySelector('[name=nama_kategori]').value = '';
+            form.querySelector('[name=description]').value = '';
+        });
+    });
+</script>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/dashboard/admin.blade.php
+++ b/resources/views/dashboard/admin.blade.php
@@ -1,0 +1,133 @@
+<?php ob_start(); ?>
+<div class="grid gap-6 lg:grid-cols-4">
+    <div class="card lg:col-span-2">
+        <div class="text-sm text-slate-500">Total Incoming Letters</div>
+        <div class="text-3xl font-semibold mt-2"><?= (int) $incomingCount ?></div>
+        <div class="text-xs text-slate-400 mt-2">All time records</div>
+    </div>
+    <div class="card lg:col-span-2">
+        <div class="text-sm text-slate-500">Total Outgoing Letters</div>
+        <div class="text-3xl font-semibold mt-2"><?= (int) $outgoingCount ?></div>
+        <div class="text-xs text-slate-400 mt-2">All time records</div>
+    </div>
+</div>
+<div class="grid gap-6 lg:grid-cols-3">
+    <div class="card lg:col-span-2">
+        <div class="flex items-center justify-between mb-4">
+            <h2 class="text-lg font-semibold text-slate-700">Monthly Activity</h2>
+            <div class="text-sm text-slate-400">Current Year</div>
+        </div>
+        <canvas id="dashboardChart"></canvas>
+    </div>
+    <div class="card space-y-4">
+        <h2 class="text-lg font-semibold text-slate-700">Categories</h2>
+        <div class="space-y-3 max-h-72 overflow-y-auto pr-2">
+            <?php foreach ($categories as $category): ?>
+                <div class="flex items-center justify-between p-3 bg-slate-50 rounded-lg">
+                    <div>
+                        <div class="font-semibold text-slate-700"><?= htmlspecialchars($category['nama_kategori']) ?></div>
+                        <div class="text-xs text-slate-500"><?= htmlspecialchars($category['description'] ?? '-') ?></div>
+                    </div>
+                    <div class="text-right text-sm text-slate-500">
+                        <div><?= (int) $category['incoming_count'] ?> incoming</div>
+                        <div><?= (int) $category['outgoing_count'] ?> outgoing</div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+</div>
+<div class="grid gap-6 lg:grid-cols-2">
+    <div class="table-wrapper">
+        <div class="flex items-center justify-between p-4">
+            <h2 class="text-lg font-semibold text-slate-700">Recent Incoming Letters</h2>
+        </div>
+        <table>
+            <thead>
+                <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                    <th>Letter No.</th>
+                    <th>Sender</th>
+                    <th>Date</th>
+                    <th>Category</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($recentIncoming as $letter): ?>
+                    <tr class="text-sm text-slate-600">
+                        <td><?= htmlspecialchars($letter['no_surat']) ?></td>
+                        <td><?= htmlspecialchars($letter['sender']) ?></td>
+                        <td><?= htmlspecialchars($letter['tanggal_masuk']) ?></td>
+                        <td><?= htmlspecialchars($letter['nama_kategori']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="table-wrapper">
+        <div class="flex items-center justify-between p-4">
+            <h2 class="text-lg font-semibold text-slate-700">Recent Outgoing Letters</h2>
+        </div>
+        <table>
+            <thead>
+                <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                    <th>Letter No.</th>
+                    <th>Receiver</th>
+                    <th>Date</th>
+                    <th>Category</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($recentOutgoing as $letter): ?>
+                    <tr class="text-sm text-slate-600">
+                        <td><?= htmlspecialchars($letter['no_surat']) ?></td>
+                        <td><?= htmlspecialchars($letter['receiver']) ?></td>
+                        <td><?= htmlspecialchars($letter['tanggal_keluar']) ?></td>
+                        <td><?= htmlspecialchars($letter['nama_kategori']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const ctx = document.getElementById('dashboardChart');
+        if (!ctx) return;
+        fetch('/dashboard/chart-data')
+            .then(resp => resp.json())
+            .then(data => {
+                new Chart(ctx, {
+                    type: 'line',
+                    data: {
+                        labels: data.labels,
+                        datasets: [
+                            {
+                                label: 'Incoming',
+                                data: data.incoming,
+                                borderColor: '#3b82f6',
+                                fill: false,
+                                tension: 0.4
+                            },
+                            {
+                                label: 'Outgoing',
+                                data: data.outgoing,
+                                borderColor: '#f97316',
+                                fill: false,
+                                tension: 0.4
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        plugins: {
+                            legend: { display: true }
+                        },
+                        scales: {
+                            y: { beginAtZero: true }
+                        }
+                    }
+                });
+            });
+    });
+</script>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/dashboard/staff.blade.php
+++ b/resources/views/dashboard/staff.blade.php
@@ -1,0 +1,69 @@
+<?php ob_start(); ?>
+<div class="grid gap-6 lg:grid-cols-3">
+    <div class="card">
+        <div class="text-sm text-slate-500">My Incoming Letters</div>
+        <div class="text-3xl font-semibold mt-2"><?= (int) $incomingCount ?></div>
+    </div>
+    <div class="card">
+        <div class="text-sm text-slate-500">My Outgoing Letters</div>
+        <div class="text-3xl font-semibold mt-2"><?= (int) $outgoingCount ?></div>
+    </div>
+    <div class="card">
+        <div class="text-sm text-slate-500">Latest Update</div>
+        <div class="text-3xl font-semibold mt-2">Today</div>
+        <div class="text-xs text-slate-400 mt-2">Keep your letters organized!</div>
+    </div>
+</div>
+<div class="grid gap-6 lg:grid-cols-2">
+    <div class="table-wrapper">
+        <div class="flex items-center justify-between p-4">
+            <h2 class="text-lg font-semibold text-slate-700">Recent Incoming Letters</h2>
+        </div>
+        <table>
+            <thead>
+                <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                    <th>Letter No.</th>
+                    <th>Sender</th>
+                    <th>Date</th>
+                    <th>Category</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($recentIncoming as $letter): ?>
+                    <tr class="text-sm text-slate-600">
+                        <td><?= htmlspecialchars($letter['no_surat']) ?></td>
+                        <td><?= htmlspecialchars($letter['sender']) ?></td>
+                        <td><?= htmlspecialchars($letter['tanggal_masuk']) ?></td>
+                        <td><?= htmlspecialchars($letter['nama_kategori']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="table-wrapper">
+        <div class="flex items-center justify-between p-4">
+            <h2 class="text-lg font-semibold text-slate-700">Recent Outgoing Letters</h2>
+        </div>
+        <table>
+            <thead>
+                <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                    <th>Letter No.</th>
+                    <th>Receiver</th>
+                    <th>Date</th>
+                    <th>Category</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($recentOutgoing as $letter): ?>
+                    <tr class="text-sm text-slate-600">
+                        <td><?= htmlspecialchars($letter['no_surat']) ?></td>
+                        <td><?= htmlspecialchars($letter['receiver']) ?></td>
+                        <td><?= htmlspecialchars($letter['tanggal_keluar']) ?></td>
+                        <td><?= htmlspecialchars($letter['nama_kategori']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>403 Forbidden</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-slate-900 text-white flex items-center justify-center">
+    <div class="text-center space-y-4">
+        <h1 class="text-6xl font-bold">403</h1>
+        <p class="text-xl">You are not authorized to access this resource.</p>
+        <a href="/dashboard" class="px-4 py-2 bg-blue-500 rounded-lg">Go Back</a>
+    </div>
+</body>
+</html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,116 @@
+<?php use App\Core\Auth; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars(config('app.name')) ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; background-color: #f5f6fa; }
+        .sidebar { min-width: 250px; background: linear-gradient(180deg, #1f2937 0%, #111827 100%); color: #f9fafb; }
+        .sidebar a { display: block; padding: 0.75rem 1.25rem; border-radius: 0.75rem; color: inherit; text-decoration: none; margin-bottom: 0.5rem; transition: background-color 0.2s ease, transform 0.2s ease; }
+        .sidebar a.active, .sidebar a:hover { background-color: rgba(59, 130, 246, 0.2); transform: translateX(4px); }
+        .card { background: #ffffff; border-radius: 1rem; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08); padding: 1.5rem; }
+        .table-wrapper { background: #ffffff; border-radius: 1rem; box-shadow: 0 6px 16px rgba(15, 23, 42, 0.05); overflow-x: auto; }
+        .table-wrapper table { width: 100%; border-collapse: collapse; }
+        .table-wrapper th, .table-wrapper td { padding: 0.85rem 1rem; border-bottom: 1px solid #eef2f7; }
+        .badge { border-radius: 9999px; padding: 0.25rem 0.75rem; font-size: 0.75rem; font-weight: 600; }
+        .badge-success { background-color: rgba(16, 185, 129, 0.15); color: #047857; }
+        .badge-warning { background-color: rgba(251, 191, 36, 0.15); color: #92400e; }
+        .modal { display: none; align-items: center; justify-content: center; background-color: rgba(15, 23, 42, 0.45); padding: 1.5rem; }
+        .modal:not(.hidden) { display: flex; }
+    </style>
+</head>
+<body class="min-h-screen flex bg-slate-100">
+    <?php $user = Auth::user(); ?>
+    <aside class="sidebar hidden md:flex flex-col p-6 space-y-6">
+        <div class="text-2xl font-semibold">Arsip <span class="text-blue-400">Surat</span></div>
+        <nav class="flex-1">
+            <a href="/dashboard" class="<?= str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/dashboard') ? 'active' : '' ?>">Dashboard</a>
+            <a href="/incoming-letters" class="<?= str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/incoming-letters') ? 'active' : '' ?>">Incoming Letters</a>
+            <a href="/outgoing-letters" class="<?= str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/outgoing-letters') ? 'active' : '' ?>">Outgoing Letters</a>
+            <?php if ($user && $user['role'] === 'admin'): ?>
+                <a href="/letter-categories" class="<?= str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/letter-categories') ? 'active' : '' ?>">Letter Categories</a>
+            <?php endif; ?>
+            <a href="/reports" class="<?= str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/reports') ? 'active' : '' ?>">Reports</a>
+            <?php if ($user && $user['role'] === 'admin'): ?>
+                <a href="/users" class="<?= str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/users') ? 'active' : '' ?>">User Management</a>
+                <a href="/settings" class="<?= str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/settings') ? 'active' : '' ?>">System Settings</a>
+            <?php endif; ?>
+        </nav>
+        <form method="POST" action="/logout">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <button class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg w-full">Logout</button>
+        </form>
+    </aside>
+    <div class="flex-1 flex flex-col">
+        <header class="bg-white shadow px-6 py-4 flex items-center justify-between">
+            <div class="flex items-center space-x-3">
+                <button class="md:hidden inline-flex items-center" data-toggle="#mobileMenu">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 12h16M4 18h16" /></svg>
+                </button>
+                <div class="text-xl font-semibold text-slate-700">Dashboard</div>
+            </div>
+            <div class="flex items-center space-x-4">
+                <div class="text-right">
+                    <div class="font-semibold text-slate-700"><?= htmlspecialchars($user['name'] ?? '') ?></div>
+                    <div class="text-sm text-slate-500 capitalize"><?= htmlspecialchars($user['role'] ?? '') ?></div>
+                </div>
+                <div class="h-10 w-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold">
+                    <?= strtoupper(substr($user['name'] ?? 'U', 0, 1)) ?>
+                </div>
+            </div>
+        </header>
+        <div id="mobileMenu" class="md:hidden hidden bg-slate-900 text-white p-4 space-y-4">
+            <a href="/dashboard" class="block">Dashboard</a>
+            <a href="/incoming-letters" class="block">Incoming Letters</a>
+            <a href="/outgoing-letters" class="block">Outgoing Letters</a>
+            <a href="/reports" class="block">Reports</a>
+            <?php if ($user && $user['role'] === 'admin'): ?>
+                <a href="/letter-categories" class="block">Letter Categories</a>
+                <a href="/users" class="block">User Management</a>
+                <a href="/settings" class="block">System Settings</a>
+            <?php endif; ?>
+        </div>
+        <main class="p-6 space-y-6">
+            <?php if (!empty($flashMessage = session_flash('status'))): ?>
+                <div class="transition-opacity duration-500" data-toast>
+                    <div class="bg-emerald-500 text-white px-4 py-3 rounded-lg shadow-lg inline-flex items-center space-x-2">
+                        <span><?= htmlspecialchars($flashMessage) ?></span>
+                    </div>
+                </div>
+            <?php endif; ?>
+            <?= $content ?? '' ?>
+        </main>
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            document.querySelectorAll('[data-toggle]').forEach(button => {
+                button.addEventListener('click', () => {
+                    const target = document.querySelector(button.dataset.toggle);
+                    if (target) {
+                        target.classList.toggle('hidden');
+                    }
+                });
+            });
+            document.querySelectorAll('[data-close]').forEach(button => {
+                button.addEventListener('click', () => {
+                    const target = document.querySelector(button.dataset.close);
+                    if (target) {
+                        target.classList.add('hidden');
+                    }
+                });
+            });
+            const toast = document.querySelector('[data-toast]');
+            if (toast) {
+                setTimeout(() => toast.classList.add('opacity-0'), 4000);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/resources/views/letters/incoming.blade.php
+++ b/resources/views/letters/incoming.blade.php
@@ -1,0 +1,154 @@
+<?php ob_start(); ?>
+<div class="flex items-center justify-between">
+    <h1 class="text-2xl font-semibold text-slate-700">Incoming Letters</h1>
+    <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg" data-toggle="#createIncomingModal">Add Letter</button>
+</div>
+<div class="mt-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+    <form method="GET" class="flex items-center gap-2">
+        <input type="text" name="search" value="<?= htmlspecialchars($_GET['search'] ?? '') ?>" placeholder="Search letters..." class="px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <button class="px-3 py-2 bg-slate-700 text-white rounded-lg">Search</button>
+    </form>
+</div>
+<div class="table-wrapper mt-6">
+    <table>
+        <thead>
+            <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                <th>Letter Number</th>
+                <th>Sender</th>
+                <th>Date Received</th>
+                <th>Subject</th>
+                <th>Category</th>
+                <th>Created By</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($letters as $letter): ?>
+                <tr class="text-sm text-slate-600">
+                    <td><?= htmlspecialchars($letter['no_surat']) ?></td>
+                    <td><?= htmlspecialchars($letter['sender']) ?></td>
+                    <td><?= htmlspecialchars($letter['tanggal_masuk']) ?></td>
+                    <td><?= htmlspecialchars($letter['subject']) ?></td>
+                    <td><?= htmlspecialchars($letter['nama_kategori']) ?></td>
+                    <td><?= htmlspecialchars($letter['creator']) ?></td>
+                    <td class="space-x-2">
+                        <a class="text-blue-600" href="/incoming-letters/<?= $letter['id'] ?>">View</a>
+                        <a class="text-emerald-600" href="/incoming-letters/<?= $letter['id'] ?>/download">Download</a>
+                        <button type="button" class="text-amber-600" data-toggle="#editIncomingModal" data-letter='<?= json_encode($letter) ?>'>Edit</button>
+                        <form action="/incoming-letters/<?= $letter['id'] ?>/delete" method="POST" class="inline">
+                            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+                            <button class="text-rose-600" onclick="return confirm('Delete this letter?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+
+<div id="createIncomingModal" class="modal fixed inset-0 hidden items-center justify-center">
+    <div class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full p-6 space-y-4">
+        <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-slate-700">Add Incoming Letter</h2>
+            <button data-close="#createIncomingModal">&times;</button>
+        </div>
+        <form action="/incoming-letters" method="POST" enctype="multipart/form-data" class="grid gap-4 md:grid-cols-2">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <div>
+                <label class="text-sm text-slate-500">Letter Number</label>
+                <input type="text" name="no_surat" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Sender</label>
+                <input type="text" name="sender" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Date Received</label>
+                <input type="date" name="tanggal_masuk" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Subject</label>
+                <input type="text" name="subject" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Category</label>
+                <select name="kategori_id" class="w-full px-3 py-2 border rounded-lg" required>
+                    <option value="">Select</option>
+                    <?php foreach ($categories as $category): ?>
+                        <option value="<?= $category['id'] ?>"><?= htmlspecialchars($category['nama_kategori']) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Upload PDF</label>
+                <input type="file" name="file" accept="application/pdf" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div class="md:col-span-2 flex justify-end gap-3">
+                <button type="button" class="px-4 py-2 border rounded-lg" data-close="#createIncomingModal">Cancel</button>
+                <button class="px-4 py-2 bg-blue-600 text-white rounded-lg">Save Letter</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="editIncomingModal" class="modal fixed inset-0 hidden items-center justify-center">
+    <div class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full p-6 space-y-4">
+        <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-slate-700">Edit Incoming Letter</h2>
+            <button data-close="#editIncomingModal">&times;</button>
+        </div>
+        <form id="editIncomingForm" method="POST" enctype="multipart/form-data" class="grid gap-4 md:grid-cols-2">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <div>
+                <label class="text-sm text-slate-500">Letter Number</label>
+                <input type="text" name="no_surat" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Sender</label>
+                <input type="text" name="sender" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Date Received</label>
+                <input type="date" name="tanggal_masuk" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Subject</label>
+                <input type="text" name="subject" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Category</label>
+                <select name="kategori_id" class="w-full px-3 py-2 border rounded-lg" required>
+                    <?php foreach ($categories as $category): ?>
+                        <option value="<?= $category['id'] ?>"><?= htmlspecialchars($category['nama_kategori']) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Replace File (PDF)</label>
+                <input type="file" name="file" accept="application/pdf" class="w-full px-3 py-2 border rounded-lg">
+            </div>
+            <div class="md:col-span-2 flex justify-end gap-3">
+                <button type="button" class="px-4 py-2 border rounded-lg" data-close="#editIncomingModal">Cancel</button>
+                <button class="px-4 py-2 bg-blue-600 text-white rounded-lg">Update Letter</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('[data-letter]').forEach(button => {
+            button.addEventListener('click', () => {
+                const data = JSON.parse(button.dataset.letter);
+                const form = document.getElementById('editIncomingForm');
+                form.action = `/incoming-letters/${data.id}/update`;
+                form.querySelector('[name=no_surat]').value = data.no_surat;
+                form.querySelector('[name=sender]').value = data.sender;
+                form.querySelector('[name=tanggal_masuk]').value = data.tanggal_masuk;
+                form.querySelector('[name=subject]').value = data.subject;
+                form.querySelector('[name=kategori_id]').value = data.kategori_id;
+            });
+        });
+    });
+</script>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/letters/incoming_show.blade.php
+++ b/resources/views/letters/incoming_show.blade.php
@@ -1,0 +1,18 @@
+<?php ob_start(); ?>
+<div class="card space-y-4">
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-slate-700">Incoming Letter Detail</h1>
+        <a href="/incoming-letters" class="px-3 py-2 bg-slate-200 rounded-lg">Back</a>
+    </div>
+    <div class="grid md:grid-cols-2 gap-4 text-sm text-slate-600">
+        <div><span class="font-semibold text-slate-700">Letter Number:</span> <?= htmlspecialchars($letter['no_surat']) ?></div>
+        <div><span class="font-semibold text-slate-700">Sender:</span> <?= htmlspecialchars($letter['sender']) ?></div>
+        <div><span class="font-semibold text-slate-700">Date Received:</span> <?= htmlspecialchars($letter['tanggal_masuk']) ?></div>
+        <div><span class="font-semibold text-slate-700">Subject:</span> <?= htmlspecialchars($letter['subject']) ?></div>
+        <div><span class="font-semibold text-slate-700">Category:</span> <?= htmlspecialchars($category['nama_kategori'] ?? '-') ?></div>
+    </div>
+    <div class="mt-4">
+        <iframe src="/incoming-letters/<?= $letter['id'] ?>/download?preview=1" class="w-full h-[500px] rounded-lg border"></iframe>
+    </div>
+</div>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/letters/outgoing.blade.php
+++ b/resources/views/letters/outgoing.blade.php
@@ -1,0 +1,154 @@
+<?php ob_start(); ?>
+<div class="flex items-center justify-between">
+    <h1 class="text-2xl font-semibold text-slate-700">Outgoing Letters</h1>
+    <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg" data-toggle="#createOutgoingModal">Add Letter</button>
+</div>
+<div class="mt-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+    <form method="GET" class="flex items-center gap-2">
+        <input type="text" name="search" value="<?= htmlspecialchars($_GET['search'] ?? '') ?>" placeholder="Search letters..." class="px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <button class="px-3 py-2 bg-slate-700 text-white rounded-lg">Search</button>
+    </form>
+</div>
+<div class="table-wrapper mt-6">
+    <table>
+        <thead>
+            <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                <th>Letter Number</th>
+                <th>Receiver</th>
+                <th>Date Sent</th>
+                <th>Subject</th>
+                <th>Category</th>
+                <th>Created By</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($letters as $letter): ?>
+                <tr class="text-sm text-slate-600">
+                    <td><?= htmlspecialchars($letter['no_surat']) ?></td>
+                    <td><?= htmlspecialchars($letter['receiver']) ?></td>
+                    <td><?= htmlspecialchars($letter['tanggal_keluar']) ?></td>
+                    <td><?= htmlspecialchars($letter['subject']) ?></td>
+                    <td><?= htmlspecialchars($letter['nama_kategori']) ?></td>
+                    <td><?= htmlspecialchars($letter['creator']) ?></td>
+                    <td class="space-x-2">
+                        <a class="text-blue-600" href="/outgoing-letters/<?= $letter['id'] ?>">View</a>
+                        <a class="text-emerald-600" href="/outgoing-letters/<?= $letter['id'] ?>/download">Download</a>
+                        <button type="button" class="text-amber-600" data-toggle="#editOutgoingModal" data-letter='<?= json_encode($letter) ?>'>Edit</button>
+                        <form action="/outgoing-letters/<?= $letter['id'] ?>/delete" method="POST" class="inline">
+                            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+                            <button class="text-rose-600" onclick="return confirm('Delete this letter?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+
+<div id="createOutgoingModal" class="modal fixed inset-0 hidden items-center justify-center">
+    <div class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full p-6 space-y-4">
+        <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-slate-700">Add Outgoing Letter</h2>
+            <button data-close="#createOutgoingModal">&times;</button>
+        </div>
+        <form action="/outgoing-letters" method="POST" enctype="multipart/form-data" class="grid gap-4 md:grid-cols-2">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <div>
+                <label class="text-sm text-slate-500">Letter Number</label>
+                <input type="text" name="no_surat" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Receiver</label>
+                <input type="text" name="receiver" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Date Sent</label>
+                <input type="date" name="tanggal_keluar" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Subject</label>
+                <input type="text" name="subject" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Category</label>
+                <select name="kategori_id" class="w-full px-3 py-2 border rounded-lg" required>
+                    <option value="">Select</option>
+                    <?php foreach ($categories as $category): ?>
+                        <option value="<?= $category['id'] ?>"><?= htmlspecialchars($category['nama_kategori']) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Upload PDF</label>
+                <input type="file" name="file" accept="application/pdf" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div class="md:col-span-2 flex justify-end gap-3">
+                <button type="button" class="px-4 py-2 border rounded-lg" data-close="#createOutgoingModal">Cancel</button>
+                <button class="px-4 py-2 bg-blue-600 text-white rounded-lg">Save Letter</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="editOutgoingModal" class="modal fixed inset-0 hidden items-center justify-center">
+    <div class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full p-6 space-y-4">
+        <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-slate-700">Edit Outgoing Letter</h2>
+            <button data-close="#editOutgoingModal">&times;</button>
+        </div>
+        <form id="editOutgoingForm" method="POST" enctype="multipart/form-data" class="grid gap-4 md:grid-cols-2">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <div>
+                <label class="text-sm text-slate-500">Letter Number</label>
+                <input type="text" name="no_surat" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Receiver</label>
+                <input type="text" name="receiver" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Date Sent</label>
+                <input type="date" name="tanggal_keluar" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Subject</label>
+                <input type="text" name="subject" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Category</label>
+                <select name="kategori_id" class="w-full px-3 py-2 border rounded-lg" required>
+                    <?php foreach ($categories as $category): ?>
+                        <option value="<?= $category['id'] ?>"><?= htmlspecialchars($category['nama_kategori']) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Replace File (PDF)</label>
+                <input type="file" name="file" accept="application/pdf" class="w-full px-3 py-2 border rounded-lg">
+            </div>
+            <div class="md:col-span-2 flex justify-end gap-3">
+                <button type="button" class="px-4 py-2 border rounded-lg" data-close="#editOutgoingModal">Cancel</button>
+                <button class="px-4 py-2 bg-blue-600 text-white rounded-lg">Update Letter</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('[data-letter]').forEach(button => {
+            button.addEventListener('click', () => {
+                const data = JSON.parse(button.dataset.letter);
+                const form = document.getElementById('editOutgoingForm');
+                form.action = `/outgoing-letters/${data.id}/update`;
+                form.querySelector('[name=no_surat]').value = data.no_surat;
+                form.querySelector('[name=receiver]').value = data.receiver;
+                form.querySelector('[name=tanggal_keluar]').value = data.tanggal_keluar;
+                form.querySelector('[name=subject]').value = data.subject;
+                form.querySelector('[name=kategori_id]').value = data.kategori_id;
+            });
+        });
+    });
+</script>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/letters/outgoing_show.blade.php
+++ b/resources/views/letters/outgoing_show.blade.php
@@ -1,0 +1,18 @@
+<?php ob_start(); ?>
+<div class="card space-y-4">
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-slate-700">Outgoing Letter Detail</h1>
+        <a href="/outgoing-letters" class="px-3 py-2 bg-slate-200 rounded-lg">Back</a>
+    </div>
+    <div class="grid md:grid-cols-2 gap-4 text-sm text-slate-600">
+        <div><span class="font-semibold text-slate-700">Letter Number:</span> <?= htmlspecialchars($letter['no_surat']) ?></div>
+        <div><span class="font-semibold text-slate-700">Receiver:</span> <?= htmlspecialchars($letter['receiver']) ?></div>
+        <div><span class="font-semibold text-slate-700">Date Sent:</span> <?= htmlspecialchars($letter['tanggal_keluar']) ?></div>
+        <div><span class="font-semibold text-slate-700">Subject:</span> <?= htmlspecialchars($letter['subject']) ?></div>
+        <div><span class="font-semibold text-slate-700">Category:</span> <?= htmlspecialchars($category['nama_kategori'] ?? '-') ?></div>
+    </div>
+    <div class="mt-4">
+        <iframe src="/outgoing-letters/<?= $letter['id'] ?>/download?preview=1" class="w-full h-[500px] rounded-lg border"></iframe>
+    </div>
+</div>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -1,0 +1,60 @@
+<?php ob_start(); ?>
+<div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+    <h1 class="text-2xl font-semibold text-slate-700">Reports</h1>
+    <div class="flex gap-2">
+        <a href="/reports/export/pdf?type=<?= urlencode($type) ?>&period=<?= urlencode($period) ?>&date=<?= urlencode($date) ?>" class="px-4 py-2 bg-rose-500 text-white rounded-lg">Export PDF</a>
+        <a href="/reports/export/excel?type=<?= urlencode($type) ?>&period=<?= urlencode($period) ?>&date=<?= urlencode($date) ?>" class="px-4 py-2 bg-emerald-500 text-white rounded-lg">Export Excel</a>
+    </div>
+</div>
+<form method="GET" class="card mt-6 grid md:grid-cols-4 gap-4">
+    <div>
+        <label class="text-sm text-slate-500">Letter Type</label>
+        <select name="type" class="w-full px-3 py-2 border rounded-lg">
+            <option value="incoming" <?= $type === 'incoming' ? 'selected' : '' ?>>Incoming</option>
+            <option value="outgoing" <?= $type === 'outgoing' ? 'selected' : '' ?>>Outgoing</option>
+        </select>
+    </div>
+    <div>
+        <label class="text-sm text-slate-500">Period</label>
+        <select name="period" class="w-full px-3 py-2 border rounded-lg">
+            <option value="daily" <?= $period === 'daily' ? 'selected' : '' ?>>Daily</option>
+            <option value="monthly" <?= $period === 'monthly' ? 'selected' : '' ?>>Monthly</option>
+            <option value="yearly" <?= $period === 'yearly' ? 'selected' : '' ?>>Yearly</option>
+        </select>
+    </div>
+    <div>
+        <label class="text-sm text-slate-500">Reference Date</label>
+        <input type="date" name="date" value="<?= htmlspecialchars($date) ?>" class="w-full px-3 py-2 border rounded-lg">
+    </div>
+    <div class="flex items-end">
+        <button class="px-4 py-2 bg-blue-600 text-white rounded-lg w-full">Apply Filters</button>
+    </div>
+</form>
+
+<div class="table-wrapper mt-6">
+    <table>
+        <thead>
+            <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                <th>Letter Number</th>
+                <th><?= $type === 'incoming' ? 'Sender' : 'Receiver' ?></th>
+                <th><?= $type === 'incoming' ? 'Date Received' : 'Date Sent' ?></th>
+                <th>Subject</th>
+                <th>Category</th>
+                <th>Created By</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($rows as $row): ?>
+                <tr class="text-sm text-slate-600">
+                    <td><?= htmlspecialchars($row['no_surat']) ?></td>
+                    <td><?= htmlspecialchars($type === 'incoming' ? $row['sender'] : $row['receiver']) ?></td>
+                    <td><?= htmlspecialchars($type === 'incoming' ? $row['tanggal_masuk'] : $row['tanggal_keluar']) ?></td>
+                    <td><?= htmlspecialchars($row['subject']) ?></td>
+                    <td><?= htmlspecialchars($row['nama_kategori']) ?></td>
+                    <td><?= htmlspecialchars($row['creator']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -1,0 +1,62 @@
+<?php ob_start(); ?>
+<div class="grid gap-6 lg:grid-cols-2">
+    <div class="card space-y-4">
+        <h1 class="text-xl font-semibold text-slate-700">Institution Identity</h1>
+        <form action="/settings" method="POST" enctype="multipart/form-data" class="space-y-4">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <div>
+                <label class="text-sm text-slate-500">Institution Name</label>
+                <input type="text" name="institution_name" value="<?= htmlspecialchars($settings['institution_name'] ?? '') ?>" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Address</label>
+                <textarea name="institution_address" class="w-full px-3 py-2 border rounded-lg" rows="3" required><?= htmlspecialchars($settings['institution_address'] ?? '') ?></textarea>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Logo</label>
+                <input type="file" name="logo" accept="image/*" class="w-full px-3 py-2 border rounded-lg">
+                <?php if (!empty($settings['logo_path'])):
+                    $logoFile = storage_path('app/' . $settings['logo_path']);
+                    if (file_exists($logoFile)) {
+                        $mime = mime_content_type($logoFile);
+                        $base64 = base64_encode(file_get_contents($logoFile));
+                        echo '<img src="data:' . htmlspecialchars($mime) . ';base64,' . $base64 . '" alt="Logo" class="h-16 mt-2 rounded">';
+                    }
+                endif; ?>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Max Upload Size (KB)</label>
+                <input type="number" name="max_upload_size" value="<?= htmlspecialchars($settings['max_upload_size'] ?? 10240) ?>" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div class="flex justify-end">
+                <button class="px-4 py-2 bg-blue-600 text-white rounded-lg">Save Settings</button>
+            </div>
+        </form>
+    </div>
+    <div class="space-y-6">
+        <div class="card space-y-3">
+            <h2 class="text-lg font-semibold text-slate-700">Backup & Restore</h2>
+            <a href="/settings/backup" class="px-4 py-2 bg-emerald-500 text-white rounded-lg inline-block">Generate Backup</a>
+            <form action="/settings/restore" method="POST" enctype="multipart/form-data" class="space-y-3">
+                <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+                <input type="file" name="backup" accept=".sql" class="w-full px-3 py-2 border rounded-lg" required>
+                <button class="px-4 py-2 bg-rose-500 text-white rounded-lg">Restore Database</button>
+            </form>
+        </div>
+        <div class="card space-y-3">
+            <h2 class="text-lg font-semibold text-slate-700">Audit Trail (latest)</h2>
+            <div class="max-h-64 overflow-y-auto space-y-3">
+                <?php
+                $logs = \App\Models\AuditTrail::query('SELECT a.*, u.name FROM audit_trails a JOIN users u ON u.id = a.user_id ORDER BY a.id DESC LIMIT 10');
+                foreach ($logs as $log): ?>
+                    <div class="bg-slate-50 rounded-lg px-3 py-2 text-sm">
+                        <div class="font-semibold text-slate-700"><?= htmlspecialchars($log['name']) ?> - <?= htmlspecialchars($log['action']) ?></div>
+                        <div class="text-slate-500 text-xs"><?= htmlspecialchars($log['description']) ?></div>
+                        <div class="text-slate-400 text-xs"><?= htmlspecialchars($log['created_at']) ?></div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </div>
+</div>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -1,0 +1,117 @@
+<?php ob_start(); ?>
+<div class="flex items-center justify-between">
+    <h1 class="text-2xl font-semibold text-slate-700">User Management</h1>
+    <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg" data-toggle="#userModal">Add Staff</button>
+</div>
+<div class="table-wrapper mt-6">
+    <table>
+        <thead>
+            <tr class="text-left text-xs uppercase tracking-wide text-slate-500">
+                <th>Name</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($users as $user): ?>
+                <tr class="text-sm text-slate-600">
+                    <td><?= htmlspecialchars($user['name']) ?></td>
+                    <td><?= htmlspecialchars($user['email']) ?></td>
+                    <td class="capitalize"><?= htmlspecialchars($user['role']) ?></td>
+                    <td>
+                        <span class="badge <?= $user['status'] === 'active' ? 'badge-success' : 'badge-warning' ?>"><?= htmlspecialchars($user['status']) ?></span>
+                    </td>
+                    <td class="space-x-2">
+                        <button type="button" class="text-amber-600" data-toggle="#userModal" data-user='<?= json_encode($user) ?>'>Edit</button>
+                        <form action="/users/<?= $user['id'] ?>/reset" method="POST" class="inline">
+                            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+                            <button class="text-blue-600">Reset Password</button>
+                        </form>
+                        <form action="/users/<?= $user['id'] ?>/delete" method="POST" class="inline">
+                            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+                            <button class="text-rose-600" onclick="return confirm('Delete this user?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+
+<div id="userModal" class="modal fixed inset-0 hidden items-center justify-center">
+    <div class="bg-white rounded-2xl shadow-2xl max-w-xl w-full p-6 space-y-4">
+        <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-slate-700">User Form</h2>
+            <button data-close="#userModal">&times;</button>
+        </div>
+        <form id="userForm" method="POST" class="grid gap-4 md:grid-cols-2">
+            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
+            <input type="hidden" name="_method" value="create">
+            <div class="md:col-span-2">
+                <label class="text-sm text-slate-500">Name</label>
+                <input type="text" name="name" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div class="md:col-span-2">
+                <label class="text-sm text-slate-500">Email</label>
+                <input type="email" name="email" class="w-full px-3 py-2 border rounded-lg" required>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Role</label>
+                <select name="role" class="w-full px-3 py-2 border rounded-lg">
+                    <option value="staff">Staff</option>
+                    <option value="admin">Admin</option>
+                </select>
+            </div>
+            <div>
+                <label class="text-sm text-slate-500">Status</label>
+                <select name="status" class="w-full px-3 py-2 border rounded-lg">
+                    <option value="active">Active</option>
+                    <option value="inactive">Inactive</option>
+                </select>
+            </div>
+            <div class="md:col-span-2" id="passwordField">
+                <label class="text-sm text-slate-500">Default Password</label>
+                <input type="text" name="password" class="w-full px-3 py-2 border rounded-lg" value="password123" required>
+            </div>
+            <div class="md:col-span-2 flex justify-end gap-3">
+                <button type="button" class="px-4 py-2 border rounded-lg" data-close="#userModal">Cancel</button>
+                <button class="px-4 py-2 bg-blue-600 text-white rounded-lg">Save User</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const form = document.getElementById('userForm');
+        document.querySelectorAll('[data-user]').forEach(button => {
+            button.addEventListener('click', () => {
+                const data = JSON.parse(button.dataset.user);
+                form.action = `/users/${data.id}/update`;
+                form.querySelector('[name=_method]').value = 'update';
+                form.querySelector('[name=name]').value = data.name;
+                form.querySelector('[name=email]').value = data.email;
+                form.querySelector('[name=role]').value = data.role;
+                form.querySelector('[name=status]').value = data.status;
+                const passwordField = document.getElementById('passwordField');
+                passwordField.classList.add('hidden');
+                passwordField.querySelector('input').removeAttribute('required');
+            });
+        });
+        document.querySelector('[data-toggle="#userModal"]').addEventListener('click', () => {
+            form.action = '/users';
+            form.querySelector('[name=_method]').value = 'create';
+            form.querySelector('[name=name]').value = '';
+            form.querySelector('[name=email]').value = '';
+            form.querySelector('[name=role]').value = 'staff';
+            form.querySelector('[name=status]').value = 'active';
+            const passwordField = document.getElementById('passwordField');
+            passwordField.classList.remove('hidden');
+            passwordField.querySelector('input').value = 'password123';
+            passwordField.querySelector('input').setAttribute('required', 'required');
+        });
+    });
+</script>
+<?php $content = ob_get_clean(); include resource_path('views/layouts/app.blade.php'); ?>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,3 @@
+<?php
+
+// API routes can be defined here if needed.

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Core\Response;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\IncomingLetterController;
+use App\Http\Controllers\OutgoingLetterController;
+use App\Http\Controllers\LetterCategoryController;
+use App\Http\Controllers\ReportController;
+use App\Http\Controllers\SystemSettingController;
+use App\Http\Controllers\UserController;
+use App\Http\Middleware\AdminOnly;
+use App\Http\Middleware\Authenticate;
+
+$router->get('/', function () {
+    return Response::make('', 302, ['Location' => '/dashboard']);
+});
+
+$router->get('/login', [AuthController::class, 'showLoginForm']);
+$router->post('/login', [AuthController::class, 'login']);
+$router->post('/logout', [AuthController::class, 'logout'], [Authenticate::class]);
+
+$router->get('/dashboard', [DashboardController::class, 'index'], [Authenticate::class]);
+$router->get('/dashboard/chart-data', [DashboardController::class, 'chartData'], [Authenticate::class]);
+
+$router->get('/incoming-letters', [IncomingLetterController::class, 'index'], [Authenticate::class]);
+$router->post('/incoming-letters', [IncomingLetterController::class, 'store'], [Authenticate::class]);
+$router->post('/incoming-letters/{id}/update', [IncomingLetterController::class, 'update'], [Authenticate::class]);
+$router->post('/incoming-letters/{id}/delete', [IncomingLetterController::class, 'destroy'], [Authenticate::class]);
+$router->get('/incoming-letters/{id}', [IncomingLetterController::class, 'show'], [Authenticate::class]);
+$router->get('/incoming-letters/{id}/download', [IncomingLetterController::class, 'download'], [Authenticate::class]);
+
+$router->get('/outgoing-letters', [OutgoingLetterController::class, 'index'], [Authenticate::class]);
+$router->post('/outgoing-letters', [OutgoingLetterController::class, 'store'], [Authenticate::class]);
+$router->post('/outgoing-letters/{id}/update', [OutgoingLetterController::class, 'update'], [Authenticate::class]);
+$router->post('/outgoing-letters/{id}/delete', [OutgoingLetterController::class, 'destroy'], [Authenticate::class]);
+$router->get('/outgoing-letters/{id}', [OutgoingLetterController::class, 'show'], [Authenticate::class]);
+$router->get('/outgoing-letters/{id}/download', [OutgoingLetterController::class, 'download'], [Authenticate::class]);
+
+$router->get('/letter-categories', [LetterCategoryController::class, 'index'], [Authenticate::class, AdminOnly::class]);
+$router->post('/letter-categories', [LetterCategoryController::class, 'store'], [Authenticate::class, AdminOnly::class]);
+$router->post('/letter-categories/{id}/delete', [LetterCategoryController::class, 'destroy'], [Authenticate::class, AdminOnly::class]);
+
+$router->get('/reports', [ReportController::class, 'index'], [Authenticate::class]);
+$router->get('/reports/export/pdf', [ReportController::class, 'exportPdf'], [Authenticate::class]);
+$router->get('/reports/export/excel', [ReportController::class, 'exportExcel'], [Authenticate::class]);
+
+$router->get('/users', [UserController::class, 'index'], [Authenticate::class, AdminOnly::class]);
+$router->post('/users', [UserController::class, 'store'], [Authenticate::class, AdminOnly::class]);
+$router->post('/users/{id}/update', [UserController::class, 'update'], [Authenticate::class, AdminOnly::class]);
+$router->post('/users/{id}/reset', [UserController::class, 'resetPassword'], [Authenticate::class, AdminOnly::class]);
+$router->post('/users/{id}/delete', [UserController::class, 'destroy'], [Authenticate::class, AdminOnly::class]);
+
+$router->get('/settings', [SystemSettingController::class, 'index'], [Authenticate::class, AdminOnly::class]);
+$router->post('/settings', [SystemSettingController::class, 'save'], [Authenticate::class, AdminOnly::class]);
+$router->get('/settings/backup', [SystemSettingController::class, 'backup'], [Authenticate::class, AdminOnly::class]);
+$router->post('/settings/restore', [SystemSettingController::class, 'restore'], [Authenticate::class, AdminOnly::class]);

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ApplicationTest extends TestCase
+{
+    public function testBasicMath(): void
+    {
+        $this->assertSame(4, 2 + 2);
+    }
+}

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -1,0 +1,25 @@
+<?php
+
+spl_autoload_register(function (string $class): void {
+    $prefixes = [
+        'App\\' => __DIR__ . '/../app/',
+        'Database\\Seeders\\' => __DIR__ . '/../database/seeders/',
+        'Database\\Migrations\\' => __DIR__ . '/../database/migrations/',
+    ];
+
+    foreach ($prefixes as $prefix => $baseDir) {
+        $len = strlen($prefix);
+        if (strncmp($prefix, $class, $len) !== 0) {
+            continue;
+        }
+
+        $relativeClass = substr($class, $len);
+        $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+        return;
+    }
+});
+
+require_once __DIR__ . '/../app/Support/helpers.php';

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: 'resources',
+  build: {
+    outDir: '../public/assets',
+    emptyOutDir: true
+  }
+});


### PR DESCRIPTION
## Summary
- implement a lightweight Laravel-style core with autoloading, routing, middleware, and helper utilities to run offline within the expected folder structure
- add authentication, dashboards, incoming/outgoing letter management, reporting, user management, and system settings controllers with audit logging and file validation
- craft Tailwind-based Blade views, migrations, and services for reporting exports plus database backup and restore, seeded with a default admin account

## Testing
- `php -l app/Core/Application.php app/Core/Router.php app/Core/Request.php app/Core/Response.php app/Core/Auth.php app/Core/Database.php app/Core/Validator.php app/Core/Session.php app/Exceptions/Handler.php app/Support/Env.php app/Support/helpers.php app/Http/Controllers/AuthController.php app/Http/Controllers/DashboardController.php app/Http/Controllers/IncomingLetterController.php app/Http/Controllers/OutgoingLetterController.php app/Http/Controllers/ReportController.php app/Http/Controllers/SystemSettingController.php app/Http/Controllers/UserController.php app/Services/BackupService.php app/Services/PdfExporter.php app/Services/ExcelExporter.php app/Services/ReportService.php app/Models/User.php app/Models/IncomingLetter.php app/Models/OutgoingLetter.php app/Models/LetterCategory.php app/Models/SystemSetting.php app/Models/AuditTrail.php`


------
https://chatgpt.com/codex/tasks/task_e_68cef7af2b44832f882b3299c1a506a1